### PR TITLE
Subclass MLX and JAX from abstract `types.py` and shared `types_test_base.py`

### DIFF
--- a/sequence_layers/abstract/__init__.py
+++ b/sequence_layers/abstract/__init__.py
@@ -1,0 +1,2 @@
+from sequence_layers.abstract import types
+from sequence_layers.abstract import types_test_base

--- a/sequence_layers/abstract/types.py
+++ b/sequence_layers/abstract/types.py
@@ -1,0 +1,283 @@
+"""Abstract base classes and types for SequenceLayers."""
+
+import abc
+import enum
+import fractions
+from typing import Any, Callable, Generic, Iterable, Literal, TypeVar
+
+import numpy as np
+
+# Type aliases for generic usage
+T = TypeVar('T')
+ValuesT = TypeVar('ValuesT')
+MaskT = TypeVar('MaskT')
+SequenceSelf = TypeVar('SequenceSelf', bound='Sequence')
+Shape = tuple[int, ...]
+ShapeLike = list[int] | tuple[int, ...]
+DType = Any  # Can be numpy, jax, or mlx dtype
+ChannelSpec = Any  # Typically ShapeDType or compatible
+
+class PaddingMode(enum.Enum):
+  """Supported padding modes."""
+
+  # In VALID padding mode, no padding is applied.
+  #
+  # Key properties:
+  # * The physical length of an input array to a VALID padded function shrinks,
+  #   dropping any timesteps whose inputs are computed from implicit edge
+  #   padding.
+  # * An output timestep is valid when all of its input timesteps are also
+  #   valid.
+  VALID = 'valid'
+
+  # In SAME padding mode, the input sequence is padded such that the output
+  # length is equal to the input length before applying striding.
+  #
+  # Key properties:
+  # * The input length is equal to the output length, before applying striding.
+  # * Padding of `effective_kernel_size - 1` is applied. Half is applied to the
+  #   front and half to the back. If `effective_kernel_size` is even, the extra
+  #   padding is added to the end.
+  # * An output timestep is valid when its corresponding input timestep is
+  #   valid.
+  SAME = 'same'
+
+  # In CAUSAL_VALID padding mode, the input sequence is padded such that the
+  # output length is equal to the input length before applying striding. Padding
+  # is applied such that the output timestep `to` can only depend on input
+  # timesteps at or before `ti` where `ti * output_ratio = to`.
+  #
+  # Key properties:
+  # * As in SAME padding, the input length is equal to the output length, before
+  #   applying striding.
+  # * Padding of `effective_kernel_size - 1` is applied to the front of the
+  #   sequence.
+  # * As in VALID padding, an output timestep is valid iff all of its input
+  #   timesteps are also valid.
+  CAUSAL_VALID = 'causal_valid'
+
+  # In REVERSE_CAUSAL_VALID padding mode, the input sequence is padded such that
+  # the output length is equal to the input length before applying striding.
+  # Padding is applied such that the output timestep `to` can only depend on
+  # input timesteps at or after `ti` where `ti * output_ratio = to`.
+  #
+  # Key properties:
+  # * As in SAME padding, the input length is equal to the output length, before
+  #   applying striding.
+  # * Padding of `effective_kernel_size - 1` is applied to the back of the
+  #   sequence.
+  REVERSE_CAUSAL_VALID = 'reverse_causal_valid'
+
+  # In CAUSAL padding mode, the input sequence is padded such that the output
+  # length is equal to the input length before applying striding. Padding is
+  # applied such that the output timestep `to` can only depend on input
+  # timesteps at or before `ti` where `ti * output_ratio = to`.
+  #
+  # Key properties:
+  # * As in SAME padding, the input length is equal to the output length, before
+  #   applying striding.
+  # * Padding of `effective_kernel_size - 1` is applied to the front of the
+  #   sequence.
+  # * As in SAME padding, an output timestep is valid when its corresponding
+  #   input timestep is valid.
+  CAUSAL = 'causal'
+
+  # In REVERSE_CAUSAL padding mode, the input sequence is padded such that the
+  # output length is equal to the input length before applying striding. Padding
+  # is applied such that the output timestep `to` can only depend on input
+  # timesteps at or after `ti` where `ti * output_ratio = to`.
+  #
+  # Key properties:
+  # * As in SAME padding, the input length is equal to the output length, before
+  #   applying striding.
+  # * Padding of `effective_kernel_size - 1` is applied to the back of the
+  #   sequence.
+  # * As in SAME padding, an output timestep is valid when its corresponding
+  #   input timestep is valid.
+  REVERSE_CAUSAL = 'reverse_causal'
+
+  # In SEMICAUSAL padding mode, the input sequence is padded such that the
+  # output length is equal to the input length before applying striding. Padding
+  # is applied such that the output timestep `to` can only depend on input
+  # timesteps at or before `ti` where `ti * output_ratio = to`.
+  #
+  # Key properties:
+  # * As in SAME padding, the input length is equal to the output length, before
+  #   applying striding.
+  # * Padding of `effective_kernel_size - stride` is applied to the front of the
+  #   sequence, and padding of `stride - 1` timesteps is applied to the back of
+  #   the sequence for a total of `effective_kernel_size - 1` timesteps of
+  #   padding. If `effective_kernel_size` < `stride`, then padding of
+  #   `effective_kernel_size - 1` is applied to the back of the sequence.
+  # * As in SAME padding, an output timestep is valid when its corresponding
+  #   input timestep is valid.
+  SEMICAUSAL = 'semicausal'
+
+  # In SEMICAUSAL_FULL padding mode, the input sequence is padded such that the
+  # output of the corresponding overlap-add or transpose convolution is of the
+  # same size as the input sequence and perfect reconstruction can be achieved.
+  # The reconstructed signal is of the same length or of length rounded up to
+  # cover the full input sequence.
+  SEMICAUSAL_FULL = 'semicausal_full'
+
+PaddingModeString = Literal[
+    'valid',
+    'same',
+    'causal_valid',
+    'reverse_causal_valid',
+    'causal',
+    'reverse_causal',
+    'semicausal',
+    'semicausal_full',
+]
+
+class Sequence(Generic[ValuesT, MaskT], metaclass=abc.ABCMeta):
+  """Abstract base class for Sequence."""
+
+  values: ValuesT
+  mask: MaskT
+
+  @property
+  @abc.abstractmethod
+  def shape(self) -> Shape:
+    pass
+
+  @property
+  @abc.abstractmethod
+  def ndim(self) -> int:
+    pass
+
+  @property
+  @abc.abstractmethod
+  def channel_shape(self) -> Shape:
+    pass
+    
+  @property
+  @abc.abstractmethod
+  def dtype(self) -> DType:
+    pass
+
+  @classmethod
+  @abc.abstractmethod
+  def from_values(cls, values: ValuesT) -> 'Sequence':
+    pass
+
+  @classmethod
+  @abc.abstractmethod
+  def concatenate_sequences(cls, sequences: Iterable['Sequence']) -> 'Sequence':
+    pass
+
+  @abc.abstractmethod
+  def expanded_mask(self) -> Any:
+    pass
+
+  @abc.abstractmethod
+  def apply_values(
+      self,
+      values_fn: Callable[..., ValuesT],
+      *args,
+      **kwargs,
+  ) -> 'Sequence':
+    pass
+
+  @abc.abstractmethod
+  def apply_values_masked(
+      self: SequenceSelf,
+      values_fn: Callable[..., ValuesT],
+      *args,
+      **kwargs,
+  ) -> SequenceSelf:
+    pass
+    
+  @abc.abstractmethod
+  def apply(
+      self,
+      apply_fn: Callable[..., tuple[ValuesT, MaskT]],
+      *args,
+      **kwargs,
+  ) -> 'Sequence':
+    pass
+    
+  @abc.abstractmethod
+  def apply_masked(
+      self: SequenceSelf,
+      apply_fn: Callable[..., tuple[ValuesT, MaskT]],
+      *args,
+      **kwargs,
+  ) -> SequenceSelf:
+    pass
+
+  @abc.abstractmethod
+  def astype(self: SequenceSelf, dtype: DType | None) -> SequenceSelf:
+    pass
+
+  @abc.abstractmethod
+  def lengths(self) -> Any:
+    pass
+
+  @abc.abstractmethod
+  def __getitem__(self: SequenceSelf, the_slice: Any) -> SequenceSelf:
+    pass
+
+  @abc.abstractmethod
+  def pad_time(
+      self: SequenceSelf,
+      pad_left: int,
+      pad_right: int,
+      valid: bool,
+      pad_value: Any | None = None,
+  ) -> SequenceSelf:
+    pass
+
+  @abc.abstractmethod
+  def concatenate(self, other: 'Sequence') -> 'Sequence':
+    pass
+  
+  @abc.abstractmethod
+  def mask_invalid(self, mask_value: Any | None = None) -> 'Sequence':
+    pass
+
+  @abc.abstractmethod
+  def unmask(self) -> 'Sequence':
+    pass
+
+
+class SequenceLayerConfig(metaclass=abc.ABCMeta):
+  """Configuration for a SequenceLayer."""
+
+  @abc.abstractmethod
+  def make(self) -> Any:
+    """Creates the sequence layer."""
+
+  @abc.abstractmethod
+  def copy(self, **kwargs) -> 'SequenceLayerConfig':
+    """Returns a copy of the config with updated fields."""
+
+
+class Steppable(metaclass=abc.ABCMeta):
+  """A sequence processing layer that can be executed layerwise or stepwise."""
+
+  @property
+  @abc.abstractmethod
+  def block_size(self) -> int:
+    pass
+
+  @property
+  @abc.abstractmethod
+  def output_ratio(self) -> fractions.Fraction:
+    pass
+
+  @property
+  @abc.abstractmethod
+  def supports_step(self) -> bool:
+    pass
+
+  @property
+  @abc.abstractmethod
+  def input_latency(self) -> int:
+    pass
+
+  @property
+  @abc.abstractmethod
+  def output_latency(self) -> int:
+    pass

--- a/sequence_layers/abstract/types.py
+++ b/sequence_layers/abstract/types.py
@@ -281,3 +281,14 @@ class Steppable(metaclass=abc.ABCMeta):
   @abc.abstractmethod
   def output_latency(self) -> int:
     pass
+
+  @abc.abstractmethod
+  def get_accumulated_input_latency(self, input_latency: int) -> int:
+    pass
+
+  @abc.abstractmethod
+  def get_accumulated_output_latency(self, output_latency: int) -> int:
+    pass
+
+
+

--- a/sequence_layers/abstract/types.py
+++ b/sequence_layers/abstract/types.py
@@ -290,5 +290,8 @@ class Steppable(metaclass=abc.ABCMeta):
   def get_accumulated_output_latency(self, output_latency: int) -> int:
     pass
 
-
+  @property
+  @abc.abstractmethod
+  def receptive_field(self) -> Any:
+    pass
 

--- a/sequence_layers/abstract/types_test_base.py
+++ b/sequence_layers/abstract/types_test_base.py
@@ -1,0 +1,307 @@
+"""Abstract tests for Sequence types."""
+
+import abc
+from typing import Any, Callable, Sequence as TypingSequence
+import dataclasses
+from sequence_layers.abstract import types
+
+import fractions
+from absl.testing import parameterized
+import numpy as np
+
+# We'll need a way for subclasses to provide specific factory methods/backends
+class SequenceTest(parameterized.TestCase):
+  """Abstract tests for the Sequence class."""
+
+  @abc.abstractmethod
+  def get_backend(self) -> Any:
+    """Returns the backend module (jax.numpy or mlx.core)."""
+  
+  @abc.abstractmethod
+  def create_sequence(self, values: Any, mask: Any) -> Any:
+    """Creates a Sequence instance."""
+
+  @abc.abstractmethod
+  def create_masked_sequence(self, values: Any, mask: Any) -> Any:
+     """Creates a MaskedSequence instance."""
+  
+  @abc.abstractmethod
+  def assertSequencesEqual(self, x: Any, y: Any):
+    """Asserts that two sequences are equal."""
+
+  @abc.abstractmethod
+  def assertAllEqual(self, x: Any, y: Any):
+    """Asserts that two arrays are equal."""
+    
+  @property
+  def check_trees_all_equal(self) -> Callable[[Any, Any], None]:
+    """Returns a function to check tree equality."""
+    return self.assertAllEqual
+
+  def test_mask_invalid_idempotent(self):
+    xp = self.get_backend()
+    values = xp.array([
+        [1.0, 2.0, 3.0, 4.0],
+        [10.0, 20.0, 30.0, 40.0],
+    ])
+    # Different backends might handle boolean creation differently, but standard numpy-like syntax usually works
+    mask = xp.array([[True, True, False, False], [False, False, False, True]])
+
+    x = self.create_sequence(values, mask)
+    masked = x.mask_invalid()
+    self.assertIsNot(masked, x)
+    # We can't easily check isinstance here without importing the concrete classes, 
+    # but we can check behavior or use a property if we added one. 
+    # For now, we trust the concrete tests to check types if needed, 
+    # or we could add abstract methods to check types.
+
+    masked_again = masked.mask_invalid()
+    self.assertIs(masked_again, masked)
+
+    masked2 = x.mask_invalid()
+    self.assertIsNot(masked2, masked)
+
+  @parameterized.named_parameters(
+      ('mask_value=None', 0.0, None),
+      ('mask_value=0.0', 0.0, 0.0),
+      ('mask_value=-1.0', -1.0, -1.0),
+  )
+  def test_mask_invalid(self, mask_value, expected_mask_value):
+    xp = self.get_backend()
+    values = xp.array([
+        [1.0, 2.0, 3.0, 4.0],
+        [10.0, 20.0, 30.0, 40.0],
+    ])
+    mask = xp.array([[True, True, False, False], [False, False, False, True]])
+
+    # Pass mask_value only if it is not None (to test default None behavior vs explicit value)
+    if expected_mask_value is None:
+       output = self.create_sequence(values, mask).mask_invalid()
+       fill_value = 0.0
+    else:
+       output = self.create_sequence(values, mask).mask_invalid(mask_value)
+       fill_value = mask_value
+
+    expected_values = xp.array([
+        [1.0, 2.0, fill_value, fill_value],
+        [fill_value, fill_value, fill_value, 40.0],
+    ])
+    self.check_trees_all_equal(output.values, expected_values)
+    self.check_trees_all_equal(output.mask, mask)
+
+  def test_pad_time(self):
+    xp = self.get_backend()
+    values = xp.array([
+        [1.0, 2.0, 3.0, 4.0],
+        [10.0, 20.0, 30.0, 40.0],
+    ])
+    mask = xp.array([[True, True, False, False], [False, False, False, True]])
+    
+    x = self.create_sequence(values, mask).mask_invalid()
+
+    y = x.pad_time(0, 0, valid=False)
+    self.check_trees_all_equal(y.values, x.values)
+    self.check_trees_all_equal(y.mask, x.mask)
+
+    y = x.pad_time(1, 0, valid=False)
+
+    x_left1 = self.create_sequence(
+        xp.array([
+            [0.0, 1.0, 2.0, 3.0, 4.0],
+            [0.0, 10.0, 20.0, 30.0, 40.0],
+        ]),
+        xp.array([
+            [False, True, True, False, False],
+            [False, False, False, False, True],
+        ]),
+    ).mask_invalid()
+    self.check_trees_all_equal(y.values, x_left1.values)
+    self.check_trees_all_equal(y.mask, x_left1.mask)
+
+  def _create_test_sequence(self, shape):
+    xp = self.get_backend()
+    size = 1
+    for d in shape: size *= d
+    values_np = np.arange(size, dtype=np.float32).reshape(shape)
+    mask_np = np.ones(shape[:2], dtype=bool)
+    if shape[0] > 0 and shape[1] > 1:
+        mask_np[0, 1] = False
+    
+    values = xp.array(values_np)
+    mask = xp.array(mask_np)
+    return self.create_sequence(values, mask)
+
+  def test_slice(self):
+    x = self._create_test_sequence((3, 5, 9))
+    
+    self.assertSequencesEqual(
+        x[:, 1:], self.create_masked_sequence(x.values[:, 1:], x.mask[:, 1:])
+    )
+    self.assertSequencesEqual(
+        x[:, ::2], self.create_masked_sequence(x.values[:, ::2], x.mask[:, ::2])
+    )
+    self.assertSequencesEqual(
+        x[::2, ::3], self.create_masked_sequence(x.values[::2, ::3], x.mask[::2, ::3])
+    )
+
+  def test_slice_can_slice_channel_dimensions(self):
+    x = self._create_test_sequence((3, 5, 9, 4))
+    
+    self.assertSequencesEqual(
+        x[:, 1:, :], self.create_masked_sequence(x.values[:, 1:], x.mask[:, 1:])
+    )
+    self.assertSequencesEqual(
+        x[:, ::2, :3],
+        self.create_masked_sequence(x.values[:, ::2, :3], x.mask[:, ::2]),
+    )
+
+  def test_apply_values(self):
+    xp = self.get_backend()
+    values = xp.array([
+        [-1.0, 2.0, 3.0, 4.0],
+        [10.0, -20.0, 30.0, 40.0],
+    ])
+    mask = xp.array([[True, True, False, False], [False, True, False, True]])
+    
+    x = self.create_sequence(values, mask)
+    masked = x.mask_invalid()
+    
+    # Simple abs function
+    fn = abs
+    
+    y = x.apply_values(fn)
+    self.check_trees_all_equal(y.values, fn(x.values))
+    self.check_trees_all_equal(y.mask, x.mask)
+
+    y = masked.apply_values(fn)
+    self.check_trees_all_equal(y.values, fn(masked.values))
+    self.check_trees_all_equal(y.mask, x.mask)
+
+    y = masked.apply_values_masked(fn)
+    self.check_trees_all_equal(y.values, fn(masked.values))
+    self.check_trees_all_equal(y.mask, x.mask)
+
+  def test_apply_values_args(self):
+    xp = self.get_backend()
+    values = xp.array([
+        [-1.0, 2.0, 3.0, 4.0],
+        [10.0, -20.0, 30.0, 40.0],
+    ])
+    mask = xp.array([[True, True, False, False], [False, True, False, True]])
+    x = self.create_sequence(values, mask)
+    
+    target_shape = (2, 4, 1)
+    y = x.apply_values(lambda v, s: v.reshape(s), target_shape)
+    self.check_trees_all_equal(y.values.shape, target_shape)
+    self.check_trees_all_equal(y.mask.shape, (2, 4))
+
+  def test_from_values(self):
+    xp = self.get_backend()
+    values_np = np.array([
+        [1.0, 2.0],
+        [3.0, 4.0]
+    ], dtype=np.float32)
+    values = xp.array(values_np)
+    # Get the class from an instance
+    seq = self.create_sequence(values, xp.array(np.ones(values.shape[:2], dtype=bool)))
+    SeqClass = type(seq)
+    
+    x = SeqClass.from_values(values)
+    self.check_trees_all_equal(x.values, values)
+    self.check_trees_all_equal(x.mask, xp.array(np.ones(values.shape[:2], dtype=bool)))
+
+  def test_astype(self):
+    xp = self.get_backend()
+    values_np = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+    mask_np = np.array([[True, False], [False, True]], dtype=bool)
+    
+    values = xp.array(values_np)
+    mask = xp.array(mask_np)
+    
+    x = self.create_sequence(values, mask)
+    
+    # We need a dtype that matches the backend
+    if xp.__name__ == 'jax.numpy':
+       dtype = xp.int32
+    elif xp.__name__ == 'mlx.core':
+       dtype = xp.int32
+    else:
+       dtype = np.int32
+
+    y = x.astype(dtype)
+    
+    # Check values match casted version
+    self.check_trees_all_equal(y.mask, mask)
+    # y.values might be mlx array, values.astype(dtype) might be numpy if values was numpy?
+    # values is backend array. values.astype(dtype) should work if dtype is backend dtype.
+    self.check_trees_all_equal(y.values, values.astype(dtype))
+
+
+
+class SteppableTest(parameterized.TestCase):
+  """Abstract tests for Steppable layers."""
+
+  @abc.abstractmethod
+  def create_steppable(self) -> Any:
+    """Creates a basic Steppable instance that should have default properties."""
+
+  def test_steppable_defaults(self):
+    layer = self.create_steppable()
+    self.assertEqual(layer.block_size, 1)
+    self.assertEqual(layer.output_ratio, fractions.Fraction(1))
+    self.assertTrue(layer.supports_step)
+    self.assertEqual(layer.input_latency, 0)
+    self.assertEqual(layer.output_latency, 0)
+
+
+class SequenceLayerConfigTest(parameterized.TestCase):
+
+  @abc.abstractmethod
+  def get_config_base_cls(self) -> type[types.SequenceLayerConfig]:
+    """Returns the backend-specific SequenceLayerConfig class."""
+
+  def test_copy(self):
+    ConfigBase = self.get_config_base_cls()
+
+    @dataclasses.dataclass(frozen=True)
+    class Config(ConfigBase):
+      a: int = 1234
+      b: str = 'default string'
+
+      def make(self) -> Any:
+        return 'dummy_layer'
+
+    config = Config()
+    new_config = config.copy(b='new string')
+    self.assertEqual(new_config.a, config.a)
+    self.assertEqual(new_config.b, 'new string')
+
+  def test_copy_raises_on_non_dataclass(self):
+    ConfigBase = self.get_config_base_cls()
+
+    class NonDataclassConfig(ConfigBase):
+
+      def make(self) -> Any:
+        return 'dummy_layer'
+
+    config = NonDataclassConfig()
+    with self.assertRaises(TypeError):
+      new_config = config.copy()
+      del new_config
+
+  def test_copy_disallows_new_fields(self):
+    ConfigBase = self.get_config_base_cls()
+
+    @dataclasses.dataclass(frozen=True)
+    class Config(ConfigBase):
+
+      def make(self) -> Any:
+        return 'dummy_layer'
+
+    config = Config()
+    # dataclasses.replace raises TypeError for unknown arguments
+    # JAX implementation wraps it in AttributeError
+    with self.assertRaises((TypeError, AttributeError)):
+      new_config = config.copy(field_does_not_exist=1234)
+      del new_config
+

--- a/sequence_layers/abstract/types_test_base.py
+++ b/sequence_layers/abstract/types_test_base.py
@@ -9,30 +9,59 @@ import fractions
 from absl.testing import parameterized
 import numpy as np
 
-# We'll need a way for subclasses to provide specific factory methods/backends
-class SequenceTest(parameterized.TestCase):
+class SequenceLayerTest(parameterized.TestCase):
+  """Base abstract test class providing common sequence testing assertions."""
+
+  @abc.abstractmethod
+  def assertSequencesClose(self, x: Any, y: Any, **kwargs):
+    pass
+
+  @abc.abstractmethod
+  def assertSequencesNotClose(self, x: Any, y: Any, **kwargs):
+    pass
+
+  @abc.abstractmethod
+  def assertSequencesEqual(self, x: Any, y: Any):
+    pass
+
+  @abc.abstractmethod
+  def assertSequencesNotEqual(self, x: Any, y: Any):
+    pass
+
+  @abc.abstractmethod
+  def assertAllEqual(self, x: Any, y: Any):
+    pass
+
+  @abc.abstractmethod
+  def assertAllClose(self, x: Any, y: Any, **kwargs):
+    pass
+
+  @abc.abstractmethod
+  def assertNotAllEqual(self, x: Any, y: Any):
+    pass
+
+  @abc.abstractmethod
+  def assertNotAllClose(self, x: Any, y: Any, **kwargs):
+    pass
+
+
+class SequenceTest(SequenceLayerTest):
   """Abstract tests for the Sequence class."""
 
   @abc.abstractmethod
   def get_backend(self) -> Any:
     """Returns the backend module (jax.numpy or mlx.core)."""
   
+  @property
   @abc.abstractmethod
-  def create_sequence(self, values: Any, mask: Any) -> Any:
-    """Creates a Sequence instance."""
+  def Sequence(self) -> type[types.Sequence]:
+    """Returns the Sequence class for the backend."""
 
+  @property
   @abc.abstractmethod
-  def create_masked_sequence(self, values: Any, mask: Any) -> Any:
-     """Creates a MaskedSequence instance."""
+  def MaskedSequence(self) -> Any:
+     """Returns the MaskedSequence class for the backend."""
   
-  @abc.abstractmethod
-  def assertSequencesEqual(self, x: Any, y: Any):
-    """Asserts that two sequences are equal."""
-
-  @abc.abstractmethod
-  def assertAllEqual(self, x: Any, y: Any):
-    """Asserts that two arrays are equal."""
-    
   @property
   def check_trees_all_equal(self) -> Callable[[Any, Any], None]:
     """Returns a function to check tree equality."""
@@ -47,7 +76,7 @@ class SequenceTest(parameterized.TestCase):
     # Different backends might handle boolean creation differently, but standard numpy-like syntax usually works
     mask = xp.array([[True, True, False, False], [False, False, False, True]])
 
-    x = self.create_sequence(values, mask)
+    x = self.Sequence(values, mask)
     masked = x.mask_invalid()
     self.assertIsNot(masked, x)
     # We can't easily check isinstance here without importing the concrete classes, 
@@ -76,10 +105,10 @@ class SequenceTest(parameterized.TestCase):
 
     # Pass mask_value only if it is not None (to test default None behavior vs explicit value)
     if expected_mask_value is None:
-       output = self.create_sequence(values, mask).mask_invalid()
+       output = self.Sequence(values, mask).mask_invalid()
        fill_value = 0.0
     else:
-       output = self.create_sequence(values, mask).mask_invalid(mask_value)
+       output = self.Sequence(values, mask).mask_invalid(mask_value)
        fill_value = mask_value
 
     expected_values = xp.array([
@@ -97,7 +126,7 @@ class SequenceTest(parameterized.TestCase):
     ])
     mask = xp.array([[True, True, False, False], [False, False, False, True]])
     
-    x = self.create_sequence(values, mask).mask_invalid()
+    x = self.Sequence(values, mask).mask_invalid()
 
     y = x.pad_time(0, 0, valid=False)
     self.check_trees_all_equal(y.values, x.values)
@@ -105,7 +134,7 @@ class SequenceTest(parameterized.TestCase):
 
     y = x.pad_time(1, 0, valid=False)
 
-    x_left1 = self.create_sequence(
+    x_left1 = self.Sequence(
         xp.array([
             [0.0, 1.0, 2.0, 3.0, 4.0],
             [0.0, 10.0, 20.0, 30.0, 40.0],
@@ -129,30 +158,30 @@ class SequenceTest(parameterized.TestCase):
     
     values = xp.array(values_np)
     mask = xp.array(mask_np)
-    return self.create_sequence(values, mask)
+    return self.Sequence(values, mask)
 
   def test_slice(self):
     x = self._create_test_sequence((3, 5, 9))
     
     self.assertSequencesEqual(
-        x[:, 1:], self.create_masked_sequence(x.values[:, 1:], x.mask[:, 1:])
+        x[:, 1:], self.Sequence(x.values[:, 1:], x.mask[:, 1:])
     )
     self.assertSequencesEqual(
-        x[:, ::2], self.create_masked_sequence(x.values[:, ::2], x.mask[:, ::2])
+        x[:, ::2], self.Sequence(x.values[:, ::2], x.mask[:, ::2])
     )
     self.assertSequencesEqual(
-        x[::2, ::3], self.create_masked_sequence(x.values[::2, ::3], x.mask[::2, ::3])
+        x[::2, ::3], self.Sequence(x.values[::2, ::3], x.mask[::2, ::3])
     )
 
   def test_slice_can_slice_channel_dimensions(self):
     x = self._create_test_sequence((3, 5, 9, 4))
     
     self.assertSequencesEqual(
-        x[:, 1:, :], self.create_masked_sequence(x.values[:, 1:], x.mask[:, 1:])
+        x[:, 1:, :], self.Sequence(x.values[:, 1:], x.mask[:, 1:])
     )
     self.assertSequencesEqual(
         x[:, ::2, :3],
-        self.create_masked_sequence(x.values[:, ::2, :3], x.mask[:, ::2]),
+        self.Sequence(x.values[:, ::2, :3], x.mask[:, ::2]),
     )
 
   def test_apply_values(self):
@@ -163,7 +192,7 @@ class SequenceTest(parameterized.TestCase):
     ])
     mask = xp.array([[True, True, False, False], [False, True, False, True]])
     
-    x = self.create_sequence(values, mask)
+    x = self.Sequence(values, mask)
     masked = x.mask_invalid()
     
     # Simple abs function
@@ -188,7 +217,7 @@ class SequenceTest(parameterized.TestCase):
         [10.0, -20.0, 30.0, 40.0],
     ])
     mask = xp.array([[True, True, False, False], [False, True, False, True]])
-    x = self.create_sequence(values, mask)
+    x = self.Sequence(values, mask)
     
     target_shape = (2, 4, 1)
     y = x.apply_values(lambda v, s: v.reshape(s), target_shape)
@@ -203,7 +232,7 @@ class SequenceTest(parameterized.TestCase):
     ], dtype=np.float32)
     values = xp.array(values_np)
     # Get the class from an instance
-    seq = self.create_sequence(values, xp.array(np.ones(values.shape[:2], dtype=bool)))
+    seq = self.Sequence(values, xp.array(np.ones(values.shape[:2], dtype=bool)))
     SeqClass = type(seq)
     
     x = SeqClass.from_values(values)
@@ -218,7 +247,7 @@ class SequenceTest(parameterized.TestCase):
     values = xp.array(values_np)
     mask = xp.array(mask_np)
     
-    x = self.create_sequence(values, mask)
+    x = self.Sequence(values, mask)
     
     # We need a dtype that matches the backend
     if xp.__name__ == 'jax.numpy':
@@ -254,7 +283,7 @@ class SteppableTest(parameterized.TestCase):
     self.assertEqual(layer.output_latency, 0)
 
 
-class SequenceLayerConfigTest(parameterized.TestCase):
+class SequenceLayerConfigTest(SequenceLayerTest):
 
   @abc.abstractmethod
   def get_config_base_cls(self) -> type[types.SequenceLayerConfig]:

--- a/sequence_layers/abstract/types_test_base.py
+++ b/sequence_layers/abstract/types_test_base.py
@@ -281,6 +281,8 @@ class SteppableTest(parameterized.TestCase):
     self.assertTrue(layer.supports_step)
     self.assertEqual(layer.input_latency, 0)
     self.assertEqual(layer.output_latency, 0)
+    self.assertEqual(layer.get_accumulated_input_latency(0), 0)
+    self.assertEqual(layer.get_accumulated_output_latency(0), 0)
 
 
 class SequenceLayerConfigTest(SequenceLayerTest):

--- a/sequence_layers/jax/types.py
+++ b/sequence_layers/jax/types.py
@@ -808,6 +808,7 @@ class Steppable(types.Steppable):
     return int(output_latency * output_ratio) + self.output_latency
 
   @property
+  @override
   def receptive_field(self) -> ReceptiveField:
     """Returns the range of the receptive field of this layer.
 

--- a/sequence_layers/jax/types.py
+++ b/sequence_layers/jax/types.py
@@ -20,7 +20,7 @@ import fractions
 import functools
 import math
 import typing
-from typing import Any, Callable, Generic, Iterable, Literal, MutableMapping, ParamSpec, Protocol, Self, Sequence as TypingSequence, TypeVar
+from typing import Any, Callable, Generic, Iterable, Literal, MutableMapping, ParamSpec, Protocol, Self, Sequence as TypingSequence, TypeVar, override
 
 from absl import logging
 from flax import linen as nn
@@ -29,6 +29,8 @@ import jax
 from jax import numpy as jnp
 import jaxtyping
 import numpy as np
+
+from sequence_layers.abstract import types
 from sequence_layers.jax import sharding as sharding_lib
 from sequence_layers.jax import typing as jt
 import typeguard
@@ -187,121 +189,8 @@ ARRAY_LIKE_TYPES = (
     jax.core.ShapedArray,
 )
 
-
-class PaddingMode(enum.Enum):
-  """Supported padding modes."""
-
-  # In VALID padding mode, no padding is applied.
-  #
-  # Key properties:
-  # * The physical length of an input array to a VALID padded function shrinks,
-  #   dropping any timesteps whose inputs are computed from implicit edge
-  #   padding.
-  # * An output timestep is valid when all of its input timesteps are also
-  #   valid.
-  VALID = 'valid'
-
-  # In SAME padding mode, the input sequence is padded such that the output
-  # length is equal to the input length before applying striding.
-  #
-  # Key properties:
-  # * The input length is equal to the output length, before applying striding.
-  # * Padding of `effective_kernel_size - 1` is applied. Half is applied to the
-  #   front and half to the back. If `effective_kernel_size` is even, the extra
-  #   padding is added to the end.
-  # * An output timestep is valid when its corresponding input timestep is
-  #   valid.
-  SAME = 'same'
-
-  # In CAUSAL_VALID padding mode, the input sequence is padded such that the
-  # output length is equal to the input length before applying striding. Padding
-  # is applied such that the output timestep `to` can only depend on input
-  # timesteps at or before `ti` where `ti * output_ratio = to`.
-  #
-  # Key properties:
-  # * As in SAME padding, the input length is equal to the output length, before
-  #   applying striding.
-  # * Padding of `effective_kernel_size - 1` is applied to the front of the
-  #   sequence.
-  # * As in VALID padding, an output timestep is valid iff all of its input
-  #   timesteps are also valid.
-  CAUSAL_VALID = 'causal_valid'
-
-  # In REVERSE_CAUSAL_VALID padding mode, the input sequence is padded such that
-  # the output length is equal to the input length before applying striding.
-  # Padding is applied such that the output timestep `to` can only depend on
-  # input timesteps at or after `ti` where `ti * output_ratio = to`.
-  #
-  # Key properties:
-  # * As in SAME padding, the input length is equal to the output length, before
-  #   applying striding.
-  # * Padding of `effective_kernel_size - 1` is applied to the back of the
-  #   sequence.
-  REVERSE_CAUSAL_VALID = 'reverse_causal_valid'
-
-  # In CAUSAL padding mode, the input sequence is padded such that the output
-  # length is equal to the input length before applying striding. Padding is
-  # applied such that the output timestep `to` can only depend on input
-  # timesteps at or before `ti` where `ti * output_ratio = to`.
-  #
-  # Key properties:
-  # * As in SAME padding, the input length is equal to the output length, before
-  #   applying striding.
-  # * Padding of `effective_kernel_size - 1` is applied to the front of the
-  #   sequence.
-  # * As in SAME padding, an output timestep is valid when its corresponding
-  #   input timestep is valid.
-  CAUSAL = 'causal'
-
-  # In REVERSE_CAUSAL padding mode, the input sequence is padded such that the
-  # output length is equal to the input length before applying striding. Padding
-  # is applied such that the output timestep `to` can only depend on input
-  # timesteps at or after `ti` where `ti * output_ratio = to`.
-  #
-  # Key properties:
-  # * As in SAME padding, the input length is equal to the output length, before
-  #   applying striding.
-  # * Padding of `effective_kernel_size - 1` is applied to the back of the
-  #   sequence.
-  # * As in SAME padding, an output timestep is valid when its corresponding
-  #   input timestep is valid.
-  REVERSE_CAUSAL = 'reverse_causal'
-
-  # In SEMICAUSAL padding mode, the input sequence is padded such that the
-  # output length is equal to the input length before applying striding. Padding
-  # is applied such that the output timestep `to` can only depend on input
-  # timesteps at or before `ti` where `ti * output_ratio = to`.
-  #
-  # Key properties:
-  # * As in SAME padding, the input length is equal to the output length, before
-  #   applying striding.
-  # * Padding of `effective_kernel_size - stride` is applied to the front of the
-  #   sequence, and padding of `stride - 1` timesteps is applied to the back of
-  #   the sequence for a total of `effective_kernel_size - 1` timesteps of
-  #   padding. If `effective_kernel_size` < `stride`, then padding of
-  #   `effective_kernel_size - 1` is applied to the back of the sequence.
-  # * As in SAME padding, an output timestep is valid when its corresponding
-  #   input timestep is valid.
-  SEMICAUSAL = 'semicausal'
-
-  # In SEMICAUSAL_FULL padding mode, the input sequence is padded such that the
-  # output of the corresponding overlap-add or transpose convolution is of the
-  # same size as the input sequence and perfect reconstruction can be achieved.
-  # The reconstructed signal is of the same length or of length rounded up to
-  # cover the full input sequence.
-  SEMICAUSAL_FULL = 'semicausal_full'
-
-
-PaddingModeString = Literal[
-    'valid',
-    'same',
-    'causal_valid',
-    'reverse_causal_valid',
-    'causal',
-    'reverse_causal',
-    'semicausal',
-    'semicausal_full',
-]
+PaddingMode = types.PaddingMode
+PaddingModeString = types.PaddingModeString
 
 
 def validate_padding(padding: str) -> PaddingModeString:
@@ -365,7 +254,7 @@ def sequence_mask(lengths: LengthsT, maxlen: int) -> MaskT:
   )
 
 
-class Sequence(Generic[ValuesT, MaskT], struct.PyTreeNode):
+class Sequence(types.Sequence[ValuesT, MaskT], struct.PyTreeNode):
   """A generic sequence container that preserves masking information."""
 
   values: ValuesT
@@ -426,16 +315,19 @@ class Sequence(Generic[ValuesT, MaskT], struct.PyTreeNode):
       )
 
   @property
+  @override
   def shape(self) -> Shape:
     """Returns the shape of the sequence values."""
     return self.values.shape
 
   @property
+  @override
   def ndim(self) -> int:
     """Returns the rank of the sequence values."""
     return self.values.ndim
 
   @property
+  @override
   def channel_shape(self) -> Shape:
     """Returns the channel shape (the shape without batch and time)."""
     return self.values.shape[2:]
@@ -446,6 +338,7 @@ class Sequence(Generic[ValuesT, MaskT], struct.PyTreeNode):
     return ChannelSpec(self.channel_shape, self.dtype)
 
   @property
+  @override
   def dtype(self) -> DType:
     """Returns the dtype of the sequence values."""
     return self.values.dtype
@@ -459,6 +352,7 @@ class Sequence(Generic[ValuesT, MaskT], struct.PyTreeNode):
     return MaskedSequence(values, mask) if is_masked else Sequence(values, mask)
 
   @classmethod
+  @override
   def from_values(cls, values: ValuesT) -> 'MaskedSequence':
     """Returns a MaskedSequence for values, assuming every timestep is valid."""
     if values.ndim < 2:
@@ -466,6 +360,7 @@ class Sequence(Generic[ValuesT, MaskT], struct.PyTreeNode):
     return MaskedSequence(values, jnp.ones(values.shape[:2], jnp.bool_))
 
   @classmethod
+  @override
   def concatenate_sequences(cls, sequences: Iterable['Sequence']) -> 'Sequence':
     """Concatenates sequences and their masks on the time axis."""
     values = []
@@ -484,10 +379,12 @@ class Sequence(Generic[ValuesT, MaskT], struct.PyTreeNode):
         jnp.concatenate(values, axis=1), jnp.concatenate(masks, axis=1)
     )
 
+  @override
   def expanded_mask(self) -> ExpandedMaskT:
     """Returns the Sequence mask with dimensions expanded to match values."""
     return self.mask.reshape(self.mask.shape + (1,) * (self.values.ndim - 2))
 
+  @override
   def concatenate(self, other: 'Sequence') -> 'Sequence':
     """Concatenates this sequence with other on the time dimension."""
     values = jnp.concatenate([self.values, other.values], axis=1)
@@ -497,6 +394,7 @@ class Sequence(Generic[ValuesT, MaskT], struct.PyTreeNode):
     return_type = type(self) if type(self) is type(other) else Sequence
     return return_type(values, mask)
 
+  @override
   def apply_values(
       self,
       values_fn: Callable[..., ValuesT],
@@ -506,6 +404,7 @@ class Sequence(Generic[ValuesT, MaskT], struct.PyTreeNode):
     """Transforms values with values_fn, assuming result is unmasked."""
     return Sequence(values_fn(self.values, *args, **kwargs), self.mask)
 
+  @override
   def apply_values_masked(
       self: SequenceSelf,
       values_fn: Callable[..., ValuesT],
@@ -515,6 +414,7 @@ class Sequence(Generic[ValuesT, MaskT], struct.PyTreeNode):
     """Transforms values with values_fn, preserving masked state."""
     return type(self)(values_fn(self.values, *args, **kwargs), self.mask)
 
+  @override
   def apply(
       self,
       apply_fn: Callable[..., tuple[ValuesT, MaskT]],
@@ -525,6 +425,7 @@ class Sequence(Generic[ValuesT, MaskT], struct.PyTreeNode):
     values, mask = apply_fn(self.values, self.mask, *args, **kwargs)
     return Sequence(values, mask)
 
+  @override
   def apply_masked(
       self: SequenceSelf,
       apply_fn: Callable[..., tuple[ValuesT, MaskT]],
@@ -538,6 +439,7 @@ class Sequence(Generic[ValuesT, MaskT], struct.PyTreeNode):
     values, mask = apply_fn(self.values, self.mask, *args, **kwargs)
     return type(self)(values, mask)
 
+  @override
   def astype(
       self: SequenceSelf,
       dtype: DType | None,
@@ -545,10 +447,12 @@ class Sequence(Generic[ValuesT, MaskT], struct.PyTreeNode):
     """Returns a copy of this sequence with its values cast to dtype."""
     return type(self)(self.values.astype(dtype), self.mask)
 
+  @override
   def lengths(self) -> jt.Int[jt.ArrayT, 'B']:
     """Returns the number of valid timesteps per batch item."""
     return jnp.sum(self.mask.astype(jnp.int32), axis=1)
 
+  @override
   def __getitem__(
       self: SequenceSelf,
       the_slice: slice | tuple[int | slice | None | type(Ellipsis), ...],
@@ -566,6 +470,7 @@ class Sequence(Generic[ValuesT, MaskT], struct.PyTreeNode):
         self.values.__getitem__(the_slice), self.mask.__getitem__(the_slice[:2])
     )
 
+  @override
   def pad_time(
       self: SequenceSelf,
       pad_left: jt.ScalarInt,
@@ -620,10 +525,12 @@ class Sequence(Generic[ValuesT, MaskT], struct.PyTreeNode):
     ) // block_size * block_size - self.shape[1]
     return self.pad_time(pad_left=0, pad_right=pad_length, valid=False)
 
+  @override
   def mask_invalid(self, mask_value: complex | None = None) -> 'Sequence':
     """Returns a sequence with invalid timesteps replaced with mask_value."""
     raise NotImplementedError('Replaced below.')
 
+  @override
   def unmask(self) -> 'Sequence':
     """Returns an unmasked version of this sequence with unchanged values."""
     # We are already an unmasked sequence.
@@ -633,6 +540,7 @@ class Sequence(Generic[ValuesT, MaskT], struct.PyTreeNode):
 class MaskedSequence(Sequence[ValuesT, MaskT]):
   """Sequence whose invalid timesteps are masked to zero."""
 
+  @override
   def mask_invalid(self, mask_value: complex | None = None) -> 'Sequence':
     """Returns a sequence with invalid timesteps replaced with mask_value."""
     if mask_value is None:
@@ -640,6 +548,7 @@ class MaskedSequence(Sequence[ValuesT, MaskT]):
     else:
       return mask_invalid(self, mask_value)
 
+  @override
   def unmask(self) -> Sequence:
     """Returns an unmasked version of this sequence with unchanged values."""
     return Sequence(self.values, self.mask)
@@ -667,7 +576,7 @@ def mask_invalid(
 Sequence.mask_invalid = mask_invalid
 
 
-class MetaSequenceT(type):
+class MetaSequenceT(abc.ABCMeta):
   """A metaclass for SequenceT to support jaxtyping-style type parameters."""
 
   def __getitem__(cls, item):
@@ -760,7 +669,7 @@ def _add_custom_checker_lookup_fn(lookup_fn):
 _add_custom_checker_lookup_fn(_sequence_checker_lookup_fn)
 
 
-class Steppable(metaclass=abc.ABCMeta):
+class Steppable(types.Steppable):
   """A sequence processing layer that can be executed layerwise or stepwise.
 
   # Step-wise execution:
@@ -829,6 +738,7 @@ class Steppable(metaclass=abc.ABCMeta):
   path: str  # Provided by nn.Module.
 
   @property
+  @override
   def block_size(self) -> int:
     """The block size multiple required by the layer.
 
@@ -841,16 +751,19 @@ class Steppable(metaclass=abc.ABCMeta):
     return 1
 
   @property
+  @override
   def output_ratio(self) -> fractions.Fraction:
     """The number of output frames for one input frame."""
     return fractions.Fraction(1)
 
   @property
+  @override
   def supports_step(self) -> bool:
     """Returns whether this layer supports the SequenceLayer.step method."""
     return True
 
   @property
+  @override
   def input_latency(self) -> int:
     """Returns the input latency of this layer.
 
@@ -860,6 +773,7 @@ class Steppable(metaclass=abc.ABCMeta):
     return 0
 
   @property
+  @override
   def output_latency(self) -> int:
     """Returns the output latency of this layer.
 
@@ -1538,7 +1452,7 @@ class StatelessPointwiseFunctor(StatelessPointwise, metaclass=abc.ABCMeta):
     return y
 
 
-class SequenceLayerConfig(metaclass=abc.ABCMeta):
+class SequenceLayerConfig(types.SequenceLayerConfig):
   """Base class for SequenceLayer configuration objects.
 
   Requires a no-argument make() method which returns a SequenceLayer.

--- a/sequence_layers/jax/types.py
+++ b/sequence_layers/jax/types.py
@@ -784,10 +784,12 @@ class Steppable(types.Steppable):
     # to integer here.
     return int(self.input_latency * self.output_ratio)
 
+  @override
   def get_accumulated_input_latency(self, input_latency: int) -> int:
     """Returns the accumulated input latency of this layer."""
     return math.ceil(input_latency / self.output_ratio) + self.input_latency
 
+  @override
   def get_accumulated_output_latency(self, output_latency: int) -> int:
     """Returns the accumulated output latency of this layer."""
     output_ratio = self.output_ratio

--- a/sequence_layers/jax/types_test.py
+++ b/sequence_layers/jax/types_test.py
@@ -45,11 +45,13 @@ class SequenceTest(types_test_base.SequenceTest, test_utils.SequenceLayerTest):
   def get_backend(self):
     return jnp
 
-  def create_sequence(self, values, mask):
-    return types.Sequence(values, mask)
+  @property
+  def Sequence(self):
+    return types.Sequence
 
-  def create_masked_sequence(self, values, mask):
-    return types.MaskedSequence(values, mask)
+  @property
+  def MaskedSequence(self):
+    return types.MaskedSequence
 
   def test_type_checks(self):
     """Test type checks in Sequence.__post_init__."""

--- a/sequence_layers/jax/types_test.py
+++ b/sequence_layers/jax/types_test.py
@@ -24,6 +24,8 @@ import jax
 import jax.numpy as jnp
 import jaxtyping
 import numpy as np
+
+from sequence_layers.abstract import types_test_base
 from sequence_layers.jax import simple
 from sequence_layers.jax import test_utils
 from sequence_layers.jax import types
@@ -37,8 +39,17 @@ class Foo(nn.Module):
     return x
 
 
-class SequenceTest(test_utils.SequenceLayerTest):
+class SequenceTest(types_test_base.SequenceTest, test_utils.SequenceLayerTest):
   """Tests for the Sequence class."""
+
+  def get_backend(self):
+    return jnp
+
+  def create_sequence(self, values, mask):
+    return types.Sequence(values, mask)
+
+  def create_masked_sequence(self, values, mask):
+    return types.MaskedSequence(values, mask)
 
   def test_type_checks(self):
     """Test type checks in Sequence.__post_init__."""
@@ -96,91 +107,6 @@ class SequenceTest(test_utils.SequenceLayerTest):
     with self.assertRaises(jaxtyping.TypeCheckError):
       types.Sequence(np.zeros((2, 3, 5)), np.zeros((1, 3), dtype=jnp.bool_))
 
-  @parameterized.parameters(None, 0.0, -1.0)
-  def test_mask_invalid(self, mask_value: float | None):
-    values = jnp.array([
-        [1.0, 2.0, 3.0, 4.0],
-        [10.0, 20.0, 30.0, 40.0],
-    ])
-    mask = jnp.array([[True, True, False, False], [False, False, False, True]])
-
-    output = types.Sequence(values, mask).mask_invalid(mask_value)
-    mask_value = 0.0 if mask_value is None else mask_value
-
-    chex.assert_trees_all_equal(
-        output.values,
-        jnp.array([
-            [1.0, 2.0, mask_value, mask_value],
-            [mask_value, mask_value, mask_value, 40.0],
-        ]),
-    )
-    chex.assert_trees_all_equal(output.mask, mask)
-
-  def test_slice(self):
-    x = test_utils.random_sequence(3, 5, 9)
-
-    self.assertSequencesEqual(
-        x[:, 1:], types.MaskedSequence(x.values[:, 1:], x.mask[:, 1:])
-    )
-
-    self.assertSequencesEqual(
-        x[:, ::2], types.MaskedSequence(x.values[:, ::2], x.mask[:, ::2])
-    )
-
-    self.assertSequencesEqual(
-        x[::2, ::3], types.MaskedSequence(x.values[::2, ::3], x.mask[::2, ::3])
-    )
-
-    self.assertSequencesEqual(
-        x[1::2, 2::3],
-        types.MaskedSequence(x.values[1::2, 2::3], x.mask[1::2, 2::3]),
-    )
-
-    self.assertSequencesEqual(
-        x[1::2],
-        types.MaskedSequence(x.values[1::2, :], x.mask[1::2, :]),
-    )
-
-    with self.assertRaises(ValueError):
-      _ = typing.cast(Any, x)[0, :]
-
-    with self.assertRaises(ValueError):
-      _ = typing.cast(Any, x)[:, 0]
-
-  def test_slice_can_slice_channel_dimensions(self):
-    x = test_utils.random_sequence(3, 5, 9, 4)
-
-    self.assertSequencesEqual(
-        x[:, 1:, :], types.MaskedSequence(x.values[:, 1:], x.mask[:, 1:])
-    )
-
-    self.assertSequencesEqual(
-        x[:, ::2, :3],
-        types.MaskedSequence(x.values[:, ::2, :3], x.mask[:, ::2]),
-    )
-
-    self.assertSequencesEqual(
-        x[:, :, ::2], types.MaskedSequence(x.values[:, :, ::2], x.mask)
-    )
-
-    self.assertSequencesEqual(
-        x[:, :, ::2, :1], types.MaskedSequence(x.values[:, :, ::2, :1], x.mask)
-    )
-
-    self.assertSequencesEqual(
-        x[:, :, 0, ::2], types.MaskedSequence(x.values[:, :, 0, ::2], x.mask)
-    )
-
-    self.assertSequencesEqual(
-        x[:, :, jnp.newaxis],
-        types.MaskedSequence(jnp.expand_dims(x.values, 2), x.mask),
-    )
-
-    self.assertSequencesEqual(
-        x[:, :, ..., 0],
-        types.MaskedSequence(x.values[:, :, :, 0], x.mask),
-    )
-
   def test_mask_invalid_idempotent(self):
     values = jnp.array([
         [1.0, 2.0, 3.0, 4.0],
@@ -200,83 +126,6 @@ class SequenceTest(test_utils.SequenceLayerTest):
     masked2 = x.mask_invalid()
     self.assertIsNot(masked2, masked)
     self.assertIsInstance(masked2, types.MaskedSequence)
-
-  def test_apply_values(self):
-    values = jnp.array([
-        [-1.0, 2.0, 3.0, 4.0],
-        [10.0, -20.0, 30.0, 40.0],
-    ])
-    mask = jnp.array([[True, True, False, False], [False, True, False, True]])
-
-    x = types.Sequence(values, mask)
-    masked = x.mask_invalid()
-
-    # x stays unmasked if we use apply_values.
-    y = x.apply_values(jax.nn.relu)
-    self.assertNotIsInstance(y, types.MaskedSequence)
-    chex.assert_trees_all_equal(y.values, jax.nn.relu(x.values))
-    chex.assert_trees_all_equal(y.mask, x.mask)
-
-    # x does not become masked if we use apply_values_masked.
-    y = x.apply_values_masked(jax.nn.relu)
-    self.assertNotIsInstance(y, types.MaskedSequence)
-    chex.assert_trees_all_equal(y.values, jax.nn.relu(x.values))
-    chex.assert_trees_all_equal(y.mask, x.mask)
-
-    # masked loses its masked state if we use apply_values.
-    y = masked.apply_values(jax.nn.relu)
-    self.assertNotIsInstance(y, types.MaskedSequence)
-    chex.assert_trees_all_equal(y.values, jax.nn.relu(masked.values))
-    chex.assert_trees_all_equal(y.mask, x.mask)
-
-    # masked keeps its masked state if we use apply_values_masked.
-    y = masked.apply_values_masked(jax.nn.relu)
-    self.assertIsInstance(y, types.MaskedSequence)
-    chex.assert_trees_all_equal(y.values, jax.nn.relu(masked.values))
-    chex.assert_trees_all_equal(y.mask, x.mask)
-
-  def test_apply_values_args(self):
-    values = jnp.array([
-        [-1.0, 2.0, 3.0, 4.0],
-        [10.0, -20.0, 30.0, 40.0],
-    ])
-    mask = jnp.array([[True, True, False, False], [False, True, False, True]])
-
-    x = types.Sequence(values, mask)
-    y = x.apply_values(jnp.reshape, [2, 4, 1])
-    self.assertEqual(y.values.shape, (2, 4, 1))
-    self.assertEqual(y.mask.shape, (2, 4))
-    y = x.apply_values_masked(jnp.reshape, [2, 4, 1])
-    self.assertEqual(y.values.shape, (2, 4, 1))
-    self.assertEqual(y.mask.shape, (2, 4))
-
-  def test_pad_time(self):
-    x = types.Sequence(
-        jnp.array([
-            [1.0, 2.0, 3.0, 4.0],
-            [10.0, 20.0, 30.0, 40.0],
-        ]),
-        jnp.array([[True, True, False, False], [False, False, False, True]]),
-    ).mask_invalid()
-
-    y = x.pad_time(0, 0, valid=False)
-    chex.assert_trees_all_equal(y.values, x.values)
-    chex.assert_trees_all_equal(y.mask, x.mask)
-
-    y = x.pad_time(1, 0, valid=False)
-
-    x_left1 = types.Sequence(
-        jnp.array([
-            [0.0, 1.0, 2.0, 3.0, 4.0],
-            [0.0, 10.0, 20.0, 30.0, 40.0],
-        ]),
-        jnp.array([
-            [False, True, True, False, False],
-            [False, False, False, False, True],
-        ]),
-    ).mask_invalid()
-    chex.assert_trees_all_equal(y.values, x_left1.values)
-    chex.assert_trees_all_equal(y.mask, x_left1.mask)
 
   def test_type_annotation(self):
     if not jt.runtime_type_checking_enabled:
@@ -388,61 +237,11 @@ class SequenceTest(test_utils.SequenceLayerTest):
     self.assertAllEqual(x.lengths(), jnp.asarray([0, 0, 5, 17, 17]))
     self.assertIsInstance(x, types.MaskedSequence)
 
-  def test_from_values(self):
-    x_expected = test_utils.random_sequence(5, 17, 2).values
-    x = types.Sequence.from_values(x_expected)
 
-    # Mask is all ones.
-    self.assertAllEqual(x.mask, jnp.ones_like(x.mask))
+class SequenceLayerConfigTest(types_test_base.SequenceLayerConfigTest):
 
-    # Result is a MaskedSequence.
-    self.assertIsInstance(x, types.MaskedSequence)
-
-    # The values are unchanged by from_values.
-    self.assertAllEqual(x.values, x_expected)
-
-  def test_astype(self):
-    x_float = jnp.asarray([[1.0, 2.9, 3.14]])
-    x_float_mask = jnp.asarray([[True, True, True]], dtype=types.MASK_DTYPE)
-    x_expected = jnp.asarray([[1, 2, 3]], dtype=jnp.int8)
-    x = types.Sequence(x_float, x_float_mask).astype(jnp.int8)
-    with self.subTest('values_are_casted'):
-      self.assertAllEqual(x.values, x_expected)
-    with self.subTest('values_dtype_is_set'):
-      self.assertEqual(x.values.dtype, x_expected.dtype)
-    with self.subTest('mask_unchanged'):
-      self.assertAllEqual(x.mask, x_float_mask)
-      self.assertEqual(x.mask.dtype, x_float_mask.dtype)
-
-
-class SequenceLayerConfigTest(test_utils.SequenceLayerTest):
-
-  def test_copy(self):
-
-    @dataclasses.dataclass(frozen=True)
-    class Config(types.SequenceLayerConfig):
-      a: int = 1234
-      b: str = 'default string'
-
-      def make(self) -> simple.Identity:
-        return simple.Identity.Config().make()
-
-    config = Config()
-    new_config = config.copy(b='new string')
-    self.assertEqual(new_config.a, config.a)
-    self.assertEqual(new_config.b, 'new string')
-
-  def test_copy_raises_on_non_dataclass(self):
-
-    class NonDataclassConfig(types.SequenceLayerConfig):
-
-      def make(self) -> simple.Identity:
-        return simple.Identity.Config().make()
-
-    config = NonDataclassConfig()
-    with self.assertRaises(TypeError):
-      new_config = config.copy()
-      del new_config
+  def get_config_base_cls(self):
+    return types.SequenceLayerConfig
 
   def test_copy_raises_on_mutable_attribute(self):
 
@@ -482,18 +281,29 @@ class SequenceLayerConfigTest(test_utils.SequenceLayerTest):
       new_config = config.copy()
       del new_config
 
-  def test_copy_disallows_new_fields(self):
 
-    @dataclasses.dataclass(frozen=True)
-    class Config(types.SequenceLayerConfig):
+class SteppableTest(types_test_base.SteppableTest):
 
-      def make(self) -> simple.Identity:
-        return simple.Identity.Config().make()
+  def create_steppable(self):
 
-    config = Config()
-    with self.assertRaises(AttributeError):
-      new_config = config.copy(field_does_not_exist=1234)
-      del new_config
+    class DefaultSteppable(types.Steppable):
+
+      def layer(self, x, *, constants=None):
+        return x
+
+      def step(self, x, state, *, constants=None):
+        return x, state
+
+      def get_initial_state(self, batch_size, input_spec, *, constants=None):
+        return 0
+
+      def get_output_shape(self, input_shape, *, constants=None):
+        return input_shape
+
+      def get_output_dtype(self, input_dtype, *, constants=None):
+        return input_dtype
+
+    return DefaultSteppable()
 
 
 if __name__ == '__main__':

--- a/sequence_layers/mlx/types.py
+++ b/sequence_layers/mlx/types.py
@@ -1,15 +1,17 @@
 """Basic sequence types and hierarchy for MLX."""
 
 import abc
+import dataclasses
 import enum
 import fractions
 import functools
-from typing import Callable, Generic, Iterable, TypeVar
+from typing import Callable, Generic, Iterable, TypeVar, override
 
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 
+from sequence_layers.abstract import types
 
 # Type aliases.
 MASK_DTYPE = mx.bool_
@@ -30,6 +32,40 @@ Emits = object
 # Receptive field.
 ReceptiveField = tuple[float | int, float | int] | None
 
+
+__all__ = (
+    # go/keep-sorted start
+    'ChannelSpec',
+    'Constants',
+    'DType',
+    'Emits',
+    'Emitting',
+    'ExpandedMaskT',
+    'LengthsT',
+    'MASK_DTYPE',
+    'MaskT',
+    'MaskedSequence',
+    'PaddingMode',
+    'PreservesShape',
+    'PreservesType',
+    'ReceptiveField',
+    'Sequence',
+    'SequenceLayer',
+    'SequenceLayerConfig',
+    'Shape',
+    'ShapeDType',
+    'ShapeLike',
+    'State',
+    'Stateless',
+    'StatelessEmitting',
+    'StatelessPointwise',
+    'StatelessPointwiseFunctor',
+    'Steppable',
+    'ValuesT',
+    'check_layer',
+    'check_step',
+    # go/keep-sorted end
+)
 
 class ShapeDType:
   """Lightweight replacement for jax.ShapeDtypeStruct."""
@@ -52,23 +88,14 @@ class ShapeDType:
 
 ChannelSpec = ShapeDType
 
-
-class PaddingMode(enum.Enum):
-  VALID = 'valid'
-  SAME = 'same'
-  CAUSAL_VALID = 'causal_valid'
-  REVERSE_CAUSAL_VALID = 'reverse_causal_valid'
-  CAUSAL = 'causal'
-  REVERSE_CAUSAL = 'reverse_causal'
-  SEMICAUSAL = 'semicausal'
-  SEMICAUSAL_FULL = 'semicausal_full'
+PaddingMode = types.PaddingMode
 
 
 def sequence_mask(lengths: LengthsT, maxlen: int) -> MaskT:
   return mx.arange(maxlen)[None, :] < mx.array(lengths)[:, None]
 
 
-class Sequence(Generic[ValuesT, MaskT]):
+class Sequence(types.Sequence[ValuesT, MaskT]):
   """A generic sequence container that preserves masking information."""
 
   values: ValuesT
@@ -79,16 +106,19 @@ class Sequence(Generic[ValuesT, MaskT]):
     self.mask = mask
 
   @property
+  @override
   def shape(self) -> Shape:
     """Returns the shape of the sequence values."""
     return self.values.shape
 
   @property
+  @override
   def ndim(self) -> int:
     """Returns the rank of the sequence values."""
     return self.values.ndim
 
   @property
+  @override
   def channel_shape(self) -> Shape:
     """Returns the channel shape (the shape without batch and time)."""
     return self.values.shape[2:]
@@ -99,11 +129,13 @@ class Sequence(Generic[ValuesT, MaskT]):
     return ChannelSpec(self.channel_shape, self.dtype)
 
   @property
+  @override
   def dtype(self) -> DType:
     """Returns the dtype of the sequence values."""
     return self.values.dtype
 
   @classmethod
+  @override
   def from_values(cls, values: ValuesT) -> 'MaskedSequence':
     """Returns a MaskedSequence assuming every timestep is valid."""
     if values.ndim < 2:
@@ -111,6 +143,7 @@ class Sequence(Generic[ValuesT, MaskT]):
     return MaskedSequence(values, mx.ones(values.shape[:2], dtype=mx.bool_))
 
   @classmethod
+  @override
   def concatenate_sequences(cls, sequences: Iterable['Sequence']) -> 'Sequence':
     """Concatenates sequences and their masks on the time axis."""
     values = []
@@ -127,10 +160,12 @@ class Sequence(Generic[ValuesT, MaskT]):
         mx.concatenate(masks, axis=1),
     )
 
+  @override
   def expanded_mask(self) -> ExpandedMaskT:
     """Returns the Sequence mask expanded to match values rank."""
     return self.mask.reshape(self.mask.shape + (1,) * (self.values.ndim - 2))
 
+  @override
   def apply_values(
       self,
       values_fn: Callable[..., ValuesT],
@@ -140,6 +175,7 @@ class Sequence(Generic[ValuesT, MaskT]):
     """Transforms values, assuming result is unmasked."""
     return Sequence(values_fn(self.values, *args, **kwargs), self.mask)
 
+  @override
   def apply_values_masked(
       self: SequenceSelf,
       values_fn: Callable[..., ValuesT],
@@ -149,6 +185,7 @@ class Sequence(Generic[ValuesT, MaskT]):
     """Transforms values, preserving masked state."""
     return type(self)(values_fn(self.values, *args, **kwargs), self.mask)
 
+  @override
   def apply(
       self,
       apply_fn: Callable[..., tuple[ValuesT, MaskT]],
@@ -159,6 +196,7 @@ class Sequence(Generic[ValuesT, MaskT]):
     values, mask = apply_fn(self.values, self.mask, *args, **kwargs)
     return Sequence(values, mask)
 
+  @override
   def apply_masked(
       self: SequenceSelf,
       apply_fn: Callable[..., tuple[ValuesT, MaskT]],
@@ -169,16 +207,19 @@ class Sequence(Generic[ValuesT, MaskT]):
     values, mask = apply_fn(self.values, self.mask, *args, **kwargs)
     return type(self)(values, mask)
 
+  @override
   def astype(self: SequenceSelf, dtype: DType | None) -> SequenceSelf:
     """Returns a copy with values cast to dtype."""
     if dtype is None:
       return self
     return type(self)(self.values.astype(dtype), self.mask)
 
+  @override
   def lengths(self) -> mx.array:
     """Returns the number of valid timesteps per batch item."""
     return mx.sum(self.mask.astype(mx.int32), axis=1)
 
+  @override
   def __getitem__(
       self: SequenceSelf,
       the_slice,
@@ -191,6 +232,7 @@ class Sequence(Generic[ValuesT, MaskT]):
         self.mask.__getitem__(the_slice[:2]),
     )
 
+  @override
   def pad_time(
       self: SequenceSelf,
       pad_left: int,
@@ -215,6 +257,7 @@ class Sequence(Generic[ValuesT, MaskT]):
     )
     return type(self)(values, mask)
 
+  @override
   def concatenate(self, other: 'Sequence') -> 'Sequence':
     """Concatenates with other on the time dimension."""
     values = mx.concatenate([self.values, other.values], axis=1)
@@ -222,10 +265,12 @@ class Sequence(Generic[ValuesT, MaskT]):
     return_type = type(self) if type(self) is type(other) else Sequence
     return return_type(values, mask)
 
+  @override
   def mask_invalid(self, mask_value: complex | None = None) -> 'Sequence':
     """Returns a sequence with invalid timesteps replaced."""
     raise NotImplementedError('Replaced below.')
 
+  @override
   def unmask(self) -> 'Sequence':
     """Returns an unmasked version with unchanged values."""
     return self
@@ -234,11 +279,13 @@ class Sequence(Generic[ValuesT, MaskT]):
 class MaskedSequence(Sequence[ValuesT, MaskT]):
   """Sequence whose invalid timesteps are masked to zero."""
 
+  @override
   def mask_invalid(self, mask_value: complex | None = None) -> 'Sequence':
     if mask_value is None:
       return self
     return mask_invalid(self, mask_value)
 
+  @override
   def unmask(self) -> Sequence:
     return Sequence(self.values, self.mask)
 
@@ -328,30 +375,36 @@ def check_step(step_fn):
 # ---------------------------------------------------------------------------
 
 
-class Steppable(metaclass=abc.ABCMeta):
+class Steppable(types.Steppable):
   """A sequence processing layer that supports layer and step modes."""
 
   @property
+  @override
   def block_size(self) -> int:
     return 1
 
   @property
+  @override
   def output_ratio(self) -> fractions.Fraction:
     return fractions.Fraction(1)
 
   @property
+  @override
   def supports_step(self) -> bool:
     return True
 
   @property
+  @override
   def input_latency(self) -> int:
     return 0
 
   @property
+  @override
   def output_latency(self) -> int:
     return int(self.input_latency * self.output_ratio)
 
   @abc.abstractmethod
+  @override
   def layer(
       self, x: Sequence, *, constants: Constants | None = None
   ) -> Sequence:
@@ -363,6 +416,7 @@ class Steppable(metaclass=abc.ABCMeta):
     return self.layer(x, constants=constants), ()
 
   @abc.abstractmethod
+  @override
   def step(
       self,
       x: Sequence,
@@ -383,6 +437,7 @@ class Steppable(metaclass=abc.ABCMeta):
     return y, state, ()
 
   @abc.abstractmethod
+  @override
   def get_initial_state(
       self,
       batch_size: int,
@@ -393,6 +448,7 @@ class Steppable(metaclass=abc.ABCMeta):
     """Returns the initial state for step-wise processing."""
 
   @abc.abstractmethod
+  @override
   def get_output_shape(
       self,
       input_shape: ShapeLike,
@@ -402,6 +458,7 @@ class Steppable(metaclass=abc.ABCMeta):
     """Returns the output channel shape for an input channel shape."""
 
   @abc.abstractmethod
+  @override
   def get_output_dtype(
       self,
       input_dtype: DType,
@@ -428,6 +485,18 @@ class Steppable(metaclass=abc.ABCMeta):
 
 class SequenceLayer(nn.Module, Steppable):
   """Base MLX Module for Sequence Layers."""
+
+class SequenceLayerConfig(types.SequenceLayerConfig):
+  """Base class for SequenceLayer configuration objects."""
+
+  @abc.abstractmethod
+  def make(self) -> SequenceLayer:
+    """Builds a SequenceLayer from this config."""
+
+  def copy(self, **kwargs) -> 'SequenceLayerConfig':
+    """Returns a copy of the config with updated fields."""
+    return dataclasses.replace(self, **kwargs)
+
 
 
 # ---------------------------------------------------------------------------

--- a/sequence_layers/mlx/types.py
+++ b/sequence_layers/mlx/types.py
@@ -1,34 +1,71 @@
-"""Basic sequence types for MLX."""
+"""Basic sequence types and hierarchy for MLX."""
 
-from typing import Generic, TypeVar
+import abc
+import enum
+import fractions
+import functools
+from typing import Callable, Generic, Iterable, TypeVar
+
 import mlx.core as mx
+import mlx.nn as nn
 import numpy as np
 
-# A rank 2+ tensor of any type.
-# Note: MLX does not support jaxtyping-style shape annotations out of the box,
-# so we simply bind to mx.array.
-ValuesT = TypeVar('ValuesT', bound=mx.array)
 
-# You can also add the others if you need them:
+# Type aliases.
+MASK_DTYPE = mx.bool_
+
+ValuesT = TypeVar('ValuesT', bound=mx.array)
 MaskT = TypeVar('MaskT', bound=mx.array)
 LengthsT = TypeVar('LengthsT', bound=mx.array)
 ExpandedMaskT = TypeVar('ExpandedMaskT', bound=mx.array)
-# A "self" type alias to allow Sequence and subclasses to return their own
-# Sequence subtype.
 SequenceSelf = TypeVar('SequenceSelf', bound='Sequence')
+
 Shape = tuple[int, ...]
+ShapeLike = list[int] | tuple[int, ...]
 DType = np.dtype
+State = object  # Any pytree.
+Constants = dict[str, object]
+Emits = object
+
+# Receptive field.
+ReceptiveField = tuple[float | int, float | int] | None
+
+
+class ShapeDType:
+  """Lightweight replacement for jax.ShapeDtypeStruct."""
+
+  def __init__(self, shape: Shape, dtype: DType):
+    self.shape = shape
+    self.dtype = dtype
+
+  def __repr__(self) -> str:
+    return f'ShapeDType(shape={self.shape}, dtype={self.dtype})'
+
+  def __eq__(self, other: object) -> bool:
+    if not isinstance(other, ShapeDType):
+      return NotImplemented
+    return self.shape == other.shape and self.dtype == other.dtype
+
+  def __hash__(self) -> int:
+    return hash((self.shape, self.dtype))
+
+
+ChannelSpec = ShapeDType
+
+
+class PaddingMode(enum.Enum):
+  VALID = 'valid'
+  SAME = 'same'
+  CAUSAL_VALID = 'causal_valid'
+  REVERSE_CAUSAL_VALID = 'reverse_causal_valid'
+  CAUSAL = 'causal'
+  REVERSE_CAUSAL = 'reverse_causal'
+  SEMICAUSAL = 'semicausal'
+  SEMICAUSAL_FULL = 'semicausal_full'
 
 
 def sequence_mask(lengths: LengthsT, maxlen: int) -> MaskT:
   return mx.arange(maxlen)[None, :] < mx.array(lengths)[:, None]
-
-
-class ChannelSpec:
-  """A specification for the channel shape and dtype of a sequence."""
-
-  shape: Shape
-  dtype: DType
 
 
 class Sequence(Generic[ValuesT, MaskT]):
@@ -66,17 +103,131 @@ class Sequence(Generic[ValuesT, MaskT]):
     """Returns the dtype of the sequence values."""
     return self.values.dtype
 
+  @classmethod
+  def from_values(cls, values: ValuesT) -> 'MaskedSequence':
+    """Returns a MaskedSequence assuming every timestep is valid."""
+    if values.ndim < 2:
+      raise ValueError(f'Expected {values.ndim=} to be at least 2.')
+    return MaskedSequence(values, mx.ones(values.shape[:2], dtype=mx.bool_))
+
+  @classmethod
+  def concatenate_sequences(cls, sequences: Iterable['Sequence']) -> 'Sequence':
+    """Concatenates sequences and their masks on the time axis."""
+    values = []
+    masks = []
+    all_masked = True
+    for sequence in sequences:
+      if not isinstance(sequence, MaskedSequence):
+        all_masked = False
+      values.append(sequence.values)
+      masks.append(sequence.mask)
+    seq_type = MaskedSequence if all_masked else Sequence
+    return seq_type(
+        mx.concatenate(values, axis=1),
+        mx.concatenate(masks, axis=1),
+    )
+
   def expanded_mask(self) -> ExpandedMaskT:
-    """Returns the Sequence mask with dimensions expanded to match values."""
+    """Returns the Sequence mask expanded to match values rank."""
     return self.mask.reshape(self.mask.shape + (1,) * (self.values.ndim - 2))
 
+  def apply_values(
+      self,
+      values_fn: Callable[..., ValuesT],
+      *args,
+      **kwargs,
+  ) -> 'Sequence':
+    """Transforms values, assuming result is unmasked."""
+    return Sequence(values_fn(self.values, *args, **kwargs), self.mask)
+
+  def apply_values_masked(
+      self: SequenceSelf,
+      values_fn: Callable[..., ValuesT],
+      *args,
+      **kwargs,
+  ) -> SequenceSelf:
+    """Transforms values, preserving masked state."""
+    return type(self)(values_fn(self.values, *args, **kwargs), self.mask)
+
+  def apply(
+      self,
+      apply_fn: Callable[..., tuple[ValuesT, MaskT]],
+      *args,
+      **kwargs,
+  ) -> 'Sequence':
+    """Transforms values/mask, assuming result is unmasked."""
+    values, mask = apply_fn(self.values, self.mask, *args, **kwargs)
+    return Sequence(values, mask)
+
+  def apply_masked(
+      self: SequenceSelf,
+      apply_fn: Callable[..., tuple[ValuesT, MaskT]],
+      *args,
+      **kwargs,
+  ) -> SequenceSelf:
+    """Transforms values/mask, preserving masked state."""
+    values, mask = apply_fn(self.values, self.mask, *args, **kwargs)
+    return type(self)(values, mask)
+
+  def astype(self: SequenceSelf, dtype: DType | None) -> SequenceSelf:
+    """Returns a copy with values cast to dtype."""
+    if dtype is None:
+      return self
+    return type(self)(self.values.astype(dtype), self.mask)
+
+  def lengths(self) -> mx.array:
+    """Returns the number of valid timesteps per batch item."""
+    return mx.sum(self.mask.astype(mx.int32), axis=1)
+
+  def __getitem__(
+      self: SequenceSelf,
+      the_slice,
+  ) -> SequenceSelf:
+    """Slices the Sequence values and mask."""
+    if isinstance(the_slice, slice):
+      the_slice = (the_slice,)
+    return type(self)(
+        self.values.__getitem__(the_slice),
+        self.mask.__getitem__(the_slice[:2]),
+    )
+
+  def pad_time(
+      self: SequenceSelf,
+      pad_left: int,
+      pad_right: int,
+      valid: bool,
+      pad_value: float | None = None,
+  ) -> SequenceSelf:
+    """Pads this sequence with timesteps on the left and right."""
+    if not pad_left and not pad_right:
+      return self
+    pad_val = 0.0 if pad_value is None else pad_value
+    values_rank = self.values.ndim
+    values = mx.pad(
+        self.values,
+        [(0, 0), (pad_left, pad_right)] + [(0, 0)] * (values_rank - 2),
+        constant_values=pad_val,
+    )
+    mask = mx.pad(
+        self.mask,
+        [(0, 0), (pad_left, pad_right)],
+        constant_values=valid,
+    )
+    return type(self)(values, mask)
+
+  def concatenate(self, other: 'Sequence') -> 'Sequence':
+    """Concatenates with other on the time dimension."""
+    values = mx.concatenate([self.values, other.values], axis=1)
+    mask = mx.concatenate([self.mask, other.mask], axis=1)
+    return_type = type(self) if type(self) is type(other) else Sequence
+    return return_type(values, mask)
+
   def mask_invalid(self, mask_value: complex | None = None) -> 'Sequence':
-    """Returns a sequence with invalid timesteps replaced with mask_value."""
+    """Returns a sequence with invalid timesteps replaced."""
     raise NotImplementedError('Replaced below.')
 
   def unmask(self) -> 'Sequence':
-    """Returns an unmasked version of this sequence with unchanged values."""
-    # We are already an unmasked sequence.
+    """Returns an unmasked version with unchanged values."""
     return self
 
 
@@ -84,14 +235,11 @@ class MaskedSequence(Sequence[ValuesT, MaskT]):
   """Sequence whose invalid timesteps are masked to zero."""
 
   def mask_invalid(self, mask_value: complex | None = None) -> 'Sequence':
-    """Returns a sequence with invalid timesteps replaced with mask_value."""
     if mask_value is None:
       return self
-    else:
-      return mask_invalid(self, mask_value)
+    return mask_invalid(self, mask_value)
 
   def unmask(self) -> Sequence:
-    """Returns an unmasked version of this sequence with unchanged values."""
     return Sequence(self.values, self.mask)
 
 
@@ -99,7 +247,7 @@ def mask_invalid(
     sequence: Sequence,
     mask_value: complex | None = None,
 ) -> 'Sequence':
-  """Returns a sequence whose invalid timesteps are replaced with mask_value."""
+  """Returns a sequence with invalid timesteps replaced."""
   expanded_mask = sequence.expanded_mask()
   if mask_value is None:
     masked_values = mx.zeros_like(sequence.values)
@@ -113,5 +261,318 @@ def mask_invalid(
   return result_type(masked_values, sequence.mask)
 
 
-# Defined outside of Sequence so that mask_invalid can return a MaskedSequence.
+# Defined outside of Sequence so mask_invalid can return MaskedSequence.
 Sequence.mask_invalid = mask_invalid
+
+# ---------------------------------------------------------------------------
+# Check decorators
+# ---------------------------------------------------------------------------
+
+
+def _check_output_spec(layer, x, y, constants):
+  expected = layer.get_output_spec(x.channel_spec, constants=constants)
+  if y.channel_shape != expected.shape:
+    raise ValueError(
+        f'{layer.__class__.__name__} produced output'
+        f' ({y.channel_spec}) for input ({x.channel_spec}),'
+        ' whose shape does not match get_output_spec'
+        f' ({expected}).'
+    )
+
+
+def _check_output_ratio(layer, x, y):
+  expected_length = x.shape[1] * layer.output_ratio
+  if y.shape[1] != expected_length:
+    raise ValueError(
+        f'{layer.__class__.__name__} produced output ({y.shape})'
+        f' for input ({x.shape}), whose length does not equal'
+        f' {expected_length} (output_ratio={layer.output_ratio}).'
+    )
+
+
+def check_layer(layer_fn):
+  """Validates layer inputs and outputs."""
+
+  @functools.wraps(layer_fn)
+  def wrapper(self, x, *, constants=None):
+    y = layer_fn(self, x, constants=constants)
+    _check_output_spec(self, x, y, constants)
+    return y
+
+  return wrapper
+
+
+def check_step(step_fn):
+  """Validates step inputs and outputs."""
+
+  @functools.wraps(step_fn)
+  def wrapper(self, x, state, *, constants=None):
+    if not self.supports_step:
+      raise ValueError(f'{self.__class__.__name__} does not support step().')
+    block_size = self.block_size
+    if x.shape[1] % block_size != 0:
+      raise ValueError(
+          f'{self.__class__.__name__} received input with'
+          f' {x.shape=} not a multiple of {block_size=}.'
+      )
+    y, state = step_fn(self, x, state, constants=constants)
+    _check_output_spec(self, x, y, constants)
+    _check_output_ratio(self, x, y)
+    return y, state
+
+  return wrapper
+
+
+# ---------------------------------------------------------------------------
+# Steppable ABC
+# ---------------------------------------------------------------------------
+
+
+class Steppable(metaclass=abc.ABCMeta):
+  """A sequence processing layer that supports layer and step modes."""
+
+  @property
+  def block_size(self) -> int:
+    return 1
+
+  @property
+  def output_ratio(self) -> fractions.Fraction:
+    return fractions.Fraction(1)
+
+  @property
+  def supports_step(self) -> bool:
+    return True
+
+  @property
+  def input_latency(self) -> int:
+    return 0
+
+  @property
+  def output_latency(self) -> int:
+    return int(self.input_latency * self.output_ratio)
+
+  @abc.abstractmethod
+  def layer(
+      self, x: Sequence, *, constants: Constants | None = None
+  ) -> Sequence:
+    """Process this layer layer-wise."""
+
+  def layer_with_emits(
+      self, x: Sequence, *, constants: Constants | None = None
+  ) -> tuple[Sequence, Emits]:
+    return self.layer(x, constants=constants), ()
+
+  @abc.abstractmethod
+  def step(
+      self,
+      x: Sequence,
+      state: State,
+      *,
+      constants: Constants | None = None,
+  ) -> tuple[Sequence, State]:
+    """Process this layer step-wise."""
+
+  def step_with_emits(
+      self,
+      x: Sequence,
+      state: State,
+      *,
+      constants: Constants | None = None,
+  ) -> tuple[Sequence, State, Emits]:
+    y, state = self.step(x, state, constants=constants)
+    return y, state, ()
+
+  @abc.abstractmethod
+  def get_initial_state(
+      self,
+      batch_size: int,
+      input_spec: ChannelSpec,
+      *,
+      constants: Constants | None = None,
+  ) -> State:
+    """Returns the initial state for step-wise processing."""
+
+  @abc.abstractmethod
+  def get_output_shape(
+      self,
+      input_shape: ShapeLike,
+      *,
+      constants: Constants | None = None,
+  ) -> Shape:
+    """Returns the output channel shape for an input channel shape."""
+
+  @abc.abstractmethod
+  def get_output_dtype(
+      self,
+      input_dtype: DType,
+      *,
+      constants: Constants | None = None,
+  ) -> DType:
+    """Returns the output dtype for an input dtype."""
+
+  def get_output_spec(
+      self,
+      input_spec: ChannelSpec,
+      *,
+      constants: Constants | None = None,
+  ) -> ChannelSpec:
+    shape = self.get_output_shape(input_spec.shape, constants=constants)
+    dtype = self.get_output_dtype(input_spec.dtype, constants=constants)
+    return ChannelSpec(shape, dtype)
+
+
+# ---------------------------------------------------------------------------
+# SequenceLayer — MLX base
+# ---------------------------------------------------------------------------
+
+
+class SequenceLayer(nn.Module, Steppable):
+  """Base MLX Module for Sequence Layers."""
+
+
+# ---------------------------------------------------------------------------
+# Mixins
+# ---------------------------------------------------------------------------
+
+
+class PreservesType:
+  """Mix-in: layer does not change the input dtype."""
+
+  def get_output_dtype(
+      self, input_dtype: DType, *, constants: Constants | None = None
+  ) -> DType:
+    del constants
+    return input_dtype
+
+
+class PreservesShape:
+  """Mix-in: layer does not change the input channel shape."""
+
+  def get_output_shape(
+      self,
+      input_shape: ShapeLike,
+      *,
+      constants: Constants | None = None,
+  ) -> Shape:
+    del constants
+    return tuple(input_shape)
+
+
+# ---------------------------------------------------------------------------
+# Stateless variants
+# ---------------------------------------------------------------------------
+
+
+class Stateless(SequenceLayer):
+  """A SequenceLayer with no step state."""
+
+  def get_initial_state(
+      self,
+      batch_size: int,
+      input_spec: ChannelSpec,
+      *,
+      constants: Constants | None = None,
+  ) -> State:
+    return ()
+
+  def step(
+      self,
+      x: Sequence,
+      state: State,
+      *,
+      constants: Constants | None = None,
+  ) -> tuple[Sequence, State]:
+    return self.layer(x, constants=constants), state
+
+
+class StatelessPointwise(PreservesShape, Stateless):
+  """Stateless layer that operates pointwise (preserves shape)."""
+
+
+class StatelessPointwiseFunctor(StatelessPointwise, metaclass=abc.ABCMeta):
+  """Stateless pointwise layer defined by a fn(values, mask)."""
+
+  @abc.abstractmethod
+  def fn(self, values: ValuesT, mask: MaskT) -> tuple[ValuesT, MaskT]:
+    """Transforms each scalar in values independently."""
+
+  @property
+  def mask_required(self):
+    return True
+
+  @check_layer
+  def layer(
+      self, x: Sequence, *, constants: Constants | None = None
+  ) -> Sequence:
+    if self.mask_required:
+      y = x.apply(self.fn)
+    else:
+      y = x.apply_masked(self.fn)
+    # Ensure MaskedSequence -> Sequence conversion for apply.
+    if isinstance(y, MaskedSequence) and self.mask_required:
+      y = Sequence(y.values, y.mask)
+    return y
+
+
+# ---------------------------------------------------------------------------
+# Emitting variants
+# ---------------------------------------------------------------------------
+
+
+class Emitting(SequenceLayer, metaclass=abc.ABCMeta):
+  """A SequenceLayer that emits auxiliary tensors."""
+
+  def step(
+      self,
+      x: Sequence,
+      state: State,
+      *,
+      constants: Constants | None = None,
+  ) -> tuple[Sequence, State]:
+    y, state, _ = self.step_with_emits(x, state, constants=constants)
+    return y, state
+
+  @abc.abstractmethod
+  def step_with_emits(
+      self,
+      x: Sequence,
+      state: State,
+      *,
+      constants: Constants | None = None,
+  ) -> tuple[Sequence, State, Emits]:
+    pass
+
+  def layer(
+      self, x: Sequence, *, constants: Constants | None = None
+  ) -> Sequence:
+    y, _ = self.layer_with_emits(x, constants=constants)
+    return y
+
+  @abc.abstractmethod
+  def layer_with_emits(
+      self, x: Sequence, *, constants: Constants | None = None
+  ) -> tuple[Sequence, Emits]:
+    pass
+
+
+class StatelessEmitting(Emitting):
+  """Stateless layer that emits auxiliary tensors."""
+
+  def step_with_emits(
+      self,
+      x: Sequence,
+      state: State,
+      *,
+      constants: Constants | None = None,
+  ) -> tuple[Sequence, State, Emits]:
+    y, emits = self.layer_with_emits(x, constants=constants)
+    return y, state, emits
+
+  def get_initial_state(
+      self,
+      batch_size: int,
+      input_spec: ChannelSpec,
+      *,
+      constants: Constants | None = None,
+  ) -> State:
+    return ()

--- a/sequence_layers/mlx/types.py
+++ b/sequence_layers/mlx/types.py
@@ -422,7 +422,10 @@ class Steppable(types.Steppable):
       )
     return int(output_latency * output_ratio) + self.output_latency
 
-
+  @property
+  @override
+  def receptive_field(self) -> ReceptiveField:
+    raise NotImplementedError('receptive_field is not implemented by MLX Steppable.')
 
 
   @abc.abstractmethod

--- a/sequence_layers/mlx/types.py
+++ b/sequence_layers/mlx/types.py
@@ -403,6 +403,28 @@ class Steppable(types.Steppable):
   def output_latency(self) -> int:
     return int(self.input_latency * self.output_ratio)
 
+  @override
+  def get_accumulated_input_latency(self, input_latency: int) -> int:
+    import math
+    return math.ceil(input_latency / self.output_ratio) + self.input_latency
+
+  @override
+  def get_accumulated_output_latency(self, output_latency: int) -> int:
+    output_ratio = self.output_ratio
+    if required_delay := -output_latency % (1 / output_ratio):
+      path = '/'.join(self.path) if hasattr(self, 'path') else self.__class__.__name__
+      raise ValueError(
+          f'Input to {self.__class__.__name__}(path={path!r}) has a step-wise'
+          f' incoming {output_latency=} which is not divisible'
+          f" by the layer's {output_ratio=}. Insert a delay of"
+          f' -output_latency % (1/output_ratio)={required_delay} before the'
+          ' layer to compensate.'
+      )
+    return int(output_latency * output_ratio) + self.output_latency
+
+
+
+
   @abc.abstractmethod
   @override
   def layer(

--- a/sequence_layers/mlx/types_test.py
+++ b/sequence_layers/mlx/types_test.py
@@ -1,31 +1,60 @@
 import mlx.core as mx
 import numpy as np
+from sequence_layers.abstract import types_test_base
 from sequence_layers.mlx import types
 from absl.testing import parameterized
 from absl.testing import absltest
 
 
-class TypesTest(parameterized.TestCase):
+class SequenceTest(types_test_base.SequenceTest):
 
-  @parameterized.named_parameters(
-      ('mask_value=None', 0.0),
-      ('mask_value=0.0', 0.0),
-      ('mask_value=-1.0', -1.0),
-  )
-  def test_mask_invalid(self, mask_value):
-    values = mx.array([
-        [1.0, 2.0, 3.0, 4.0],
-        [10.0, 20.0, 30.0, 40.0],
-    ])
-    mask = mx.array([[True, True, False, False], [False, False, False, True]])
+  def get_backend(self):
+    return mx
 
-    output = types.Sequence(values, mask).mask_invalid(mask_value)
-    expected_values = mx.array([
-        [1.0, 2.0, mask_value, mask_value],
-        [mask_value, mask_value, mask_value, 40.0],
-    ])
-    self.assertTrue(np.allclose(output.values, expected_values))
-    self.assertTrue(np.array_equal(output.mask, mask))
+  def create_sequence(self, values, mask):
+    return types.Sequence(values, mask)
+
+  def create_masked_sequence(self, values, mask):
+    return types.MaskedSequence(values, mask)
+
+  def assertAllEqual(self, a, b):
+    a = np.array(a) if isinstance(a, mx.array) else a
+    b = np.array(b) if isinstance(b, mx.array) else b
+    np.testing.assert_array_equal(a, b)
+
+  def assertSequencesEqual(self, a, b):
+    self.assertAllEqual(a.values, b.values)
+    self.assertAllEqual(a.mask, b.mask)
+
+
+class SteppableTest(types_test_base.SteppableTest):
+
+  def create_steppable(self):
+
+    class DefaultSteppable(types.Steppable):
+
+      def layer(self, x, *, constants=None):
+        return x
+
+      def step(self, x, state, *, constants=None):
+        return x, state
+
+      def get_initial_state(self, batch_size, input_spec, *, constants=None):
+        return ()
+
+      def get_output_shape(self, input_shape, *, constants=None):
+        return input_shape
+
+      def get_output_dtype(self, input_dtype, *, constants=None):
+        return input_dtype
+
+    return DefaultSteppable()
+
+
+class SequenceLayerConfigTest(types_test_base.SequenceLayerConfigTest):
+
+  def get_config_base_cls(self):
+    return types.SequenceLayerConfig
 
 
 if __name__ == '__main__':

--- a/sequence_layers/mlx/types_test.py
+++ b/sequence_layers/mlx/types_test.py
@@ -11,11 +11,13 @@ class SequenceTest(types_test_base.SequenceTest):
   def get_backend(self):
     return mx
 
-  def create_sequence(self, values, mask):
-    return types.Sequence(values, mask)
+  @property
+  def Sequence(self):
+    return types.Sequence
 
-  def create_masked_sequence(self, values, mask):
-    return types.MaskedSequence(values, mask)
+  @property
+  def MaskedSequence(self):
+    return types.MaskedSequence
 
   def assertAllEqual(self, a, b):
     a = np.array(a) if isinstance(a, mx.array) else a

--- a/sequence_layers/mlx/types_test.py
+++ b/sequence_layers/mlx/types_test.py
@@ -4,6 +4,7 @@ from sequence_layers.mlx import types
 from absl.testing import parameterized
 from absl.testing import absltest
 
+
 class TypesTest(parameterized.TestCase):
 
   @parameterized.named_parameters(
@@ -20,11 +21,12 @@ class TypesTest(parameterized.TestCase):
 
     output = types.Sequence(values, mask).mask_invalid(mask_value)
     expected_values = mx.array([
-            [1.0, 2.0, mask_value, mask_value],
-            [mask_value, mask_value, mask_value, 40.0],
-        ])
+        [1.0, 2.0, mask_value, mask_value],
+        [mask_value, mask_value, mask_value, 40.0],
+    ])
     self.assertTrue(np.allclose(output.values, expected_values))
     self.assertTrue(np.array_equal(output.mask, mask))
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Having a shared abstract parent leads to uniform interfaces and shared tests while letting per-backend implementations be flexible. This demonstrate the change for `types.py` for MLX and JAX.