### PR TITLE
refactor: Add shared specs and behaviors for Dense layers

### DIFF
--- a/sequence_layers/jax/dense.py
+++ b/sequence_layers/jax/dense.py
@@ -15,15 +15,16 @@
 
 import dataclasses
 import typing
-from typing import Callable
+from typing import Callable, override
 
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
+
 from sequence_layers.jax import meta
 from sequence_layers.jax import types
 from sequence_layers.jax import utils
-
+from sequence_layers.specs import dense as spec
 
 __all__ = (
     # go/keep-sorted start
@@ -34,11 +35,11 @@ __all__ = (
 )
 
 
-class Dense(types.Stateless, utils.EinsumCommon):
+class Dense(types.Stateless, utils.EinsumCommon, spec.Dense):
   """A basic dense layer."""
 
   @dataclasses.dataclass(frozen=True)
-  class Config(types.SequenceLayerConfig):
+  class Config(types.SequenceLayerConfig, spec.Dense.Config):
     """Dense config."""
 
     # The number of output features for the dense layer.
@@ -72,6 +73,8 @@ class Dense(types.Stateless, utils.EinsumCommon):
 
     def make(self) -> 'Dense':
       return Dense(self, name=self.name)
+
+
 
   config: Config
 
@@ -269,7 +272,7 @@ class DenseShaped(types.Stateless, utils.EinsumCommon):
     )
 
 
-class EinsumDense(types.Stateless, utils.EinsumCommon):
+class EinsumDense(types.Stateless, utils.EinsumCommon, spec.EinsumDense):
   """A dense layer that transforms the channel shape with an einsum equation.
 
   Equation input and output specs must have leading ellipses to broadcast over
@@ -291,7 +294,7 @@ class EinsumDense(types.Stateless, utils.EinsumCommon):
   """
 
   @dataclasses.dataclass(frozen=True)
-  class Config(types.SequenceLayerConfig):
+  class Config(types.SequenceLayerConfig, spec.EinsumDense.Config):
     """EinsumDense config."""
 
     # An equation describing the einsum to perform. This equation must be a
@@ -337,6 +340,8 @@ class EinsumDense(types.Stateless, utils.EinsumCommon):
 
     def make(self) -> 'EinsumDense':
       return EinsumDense(self, name=self.name)
+
+
 
   config: Config
 

--- a/sequence_layers/jax/dense_test.py
+++ b/sequence_layers/jax/dense_test.py
@@ -19,21 +19,14 @@ import flax
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
+
 from sequence_layers.jax import dense
 from sequence_layers.jax import test_utils
 from sequence_layers.jax import types
+from sequence_layers.specs import dense_behaviors as spec
 
 
-class DenseTest(test_utils.SequenceLayerTest):
-
-  def test_rank2_unsupported(self):
-    key = jax.random.PRNGKey(1234)
-    l = dense.Dense.Config(
-        3, bias_init=nn.initializers.normal(), name='dense'
-    ).make()
-    x = test_utils.random_sequence(2, 13)
-    with self.assertRaises(ValueError):
-      self.init_and_bind_layer(key, l, x)
+class DenseTest(test_utils.SequenceLayerTest, spec.DenseTest):
 
   @parameterized.parameters(((5,),), ((5, 7),))
   def test_dense(self, channels_shape):
@@ -49,7 +42,7 @@ class DenseTest(test_utils.SequenceLayerTest):
     self.assertEqual(
         l.get_output_shape_for_sequence(x), channels_shape[:-1] + (3,)
     )
-    self.verify_contract(l, x, training=False, grad_rtol=1e-5, grad_atol=1e-5)
+    self.verify_contract(l, x, training=False, rtol=1e-5, atol=1e-5, grad_rtol=1e-5, grad_atol=1e-5)
 
     chex.assert_trees_all_equal_shapes_and_dtypes(
         flax.core.meta.unbox(l.variables),
@@ -59,17 +52,6 @@ class DenseTest(test_utils.SequenceLayerTest):
                 'bias': jnp.zeros((3,)),
             }
         },
-    )
-
-  @parameterized.parameters(True, False)
-  def test_use_bias(self, use_bias):
-    """Check that use_bias controls whether a bias is created."""
-    key = jax.random.PRNGKey(1234)
-    l = dense.Dense.Config(3, use_bias=use_bias).make()
-    x = test_utils.random_sequence(2, 3, 5)
-    l = self.init_and_bind_layer(key, l, x)
-    self.assertCountEqual(
-        l.variables['params'], ['kernel', 'bias'] if use_bias else ['kernel']
     )
 
   def test_use_einsum_factory(self):
@@ -254,7 +236,7 @@ class DenseShapedTest(test_utils.SequenceLayerTest):
     )
 
 
-class EinsumDenseTest(test_utils.SequenceLayerTest):
+class EinsumDenseTest(test_utils.SequenceLayerTest, spec.EinsumDenseTest):
 
   @parameterized.parameters(
       (
@@ -461,22 +443,22 @@ class EinsumDenseTest(test_utils.SequenceLayerTest):
   @parameterized.product(
       test_utils.standard_dtype_configs(),
       (
-          dict(
-              shape=(2, 3, 5, 7, 11),
-              equation='...abc,bd->...bd',
-              output_shape=(None, 13),
-              expected_kernel_shape=(7, 13),
-              bias_axes='',
-              expected_bias_shape=None,
-          ),
-          dict(
-              shape=(2, 3, 5),
-              equation='...a,abcd->...bcd',
-              output_shape=(7, 11, 13),
-              expected_kernel_shape=(5, 7, 11, 13),
-              bias_axes='cd',
-              expected_bias_shape=(11, 13),
-          ),
+          {
+              'shape': (2, 3, 5, 7, 11),
+              'equation': '...abc,bd->...bd',
+              'output_shape': (None, 13),
+              'expected_kernel_shape': (7, 13),
+              'bias_axes': '',
+              'expected_bias_shape': None,
+          },
+          {
+              'shape': (2, 3, 5),
+              'equation': '...a,abcd->...bcd',
+              'output_shape': (7, 11, 13),
+              'expected_kernel_shape': (5, 7, 11, 13),
+              'bias_axes': 'cd',
+              'expected_bias_shape': (11, 13),
+          },
       ),
   )
   def test_dtypes(
@@ -535,27 +517,6 @@ class EinsumDenseTest(test_utils.SequenceLayerTest):
           + bias.astype(compute_dtype if compute_dtype else param_dtype)
       ).mask_invalid()
     self.assertSequencesClose(y, y_expected)
-
-  def test_einsum_dense_nonbroadcasting_equation(self):
-    with self.assertRaises(ValueError):
-      key = jax.random.PRNGKey(1234)
-      x = test_utils.random_sequence(2, 3, 4, 5, 6)
-      l = dense.EinsumDense.Config(
-          'btabc,bc->btad', output_shape=[None, 2]
-      ).make()
-      self.init_and_bind_layer(key, l, x)
-
-  def test_einsum_dense_inconsistent_input_shape(self):
-    key = jax.random.PRNGKey(1234)
-    x = test_utils.random_sequence(2, 3, 5)
-    l = dense.EinsumDense.Config(
-        '...abc,bc->...ad', output_shape=[None, 2]
-    ).make()
-    with self.assertRaises(ValueError):
-      self.init_and_bind_layer(key, l, x)
-    # Show it works with the right input shape.
-    x = test_utils.random_sequence(2, 3, 5, 7, 11)
-    self.assertEqual(l.get_output_shape_for_sequence(x), (5, 2))
 
 
 if __name__ == '__main__':

--- a/sequence_layers/mlx/__init__.py
+++ b/sequence_layers/mlx/__init__.py
@@ -24,9 +24,12 @@
 # If you need to expose specific layers at the package level, import them
 # explicitly instead of using a star import.
 from . import backend
+from . import dense
 from . import simple
 from . import test_utils
 from . import types
+from .dense import Dense
+from .dense import EinsumDense
 from .simple import Abs
 from .simple import Add
 from .simple import Cast
@@ -83,6 +86,7 @@ from .types import Stateless
 from .types import StatelessPointwise
 
 __all__ = [
+    'dense',
     'backend',
     'simple',
     'types',
@@ -108,6 +112,8 @@ __all__ = [
     'Emits',
     'Emitting',
     'ChannelSpec',
+    'Dense',
+    'EinsumDense',
     'Identity',
     'Relu',
     'Gelu',

--- a/sequence_layers/mlx/dense.py
+++ b/sequence_layers/mlx/dense.py
@@ -1,0 +1,356 @@
+"""Dense sequence layer for MLX."""
+
+import dataclasses
+from typing import Callable, override
+
+from mlx import nn
+import mlx.core as mx
+
+from sequence_layers.mlx import init_mapping
+from sequence_layers.mlx import types as mlx_types
+from sequence_layers.mlx.init_mapping import _to_mx_dtype
+from sequence_layers.specs import dense as spec
+
+
+class _DenseEager(mlx_types.Stateless):
+  """A basic dense layer backed by mlx.nn.Linear.
+
+  Requires in_features at initialization.
+  """
+
+  def __init__(
+      self,
+      *,
+      in_features: int,
+      features: int,
+      use_bias: bool = True,
+      activation=None,
+      compute_dtype=None,
+      param_dtype=mx.float32,
+      name: str | None = None,
+  ):
+    """Initialize _DenseEager."""
+    super().__init__()
+    self.features = features
+    self.activation = activation
+    self.compute_dtype = compute_dtype
+    self._param_dtype = param_dtype
+    self.name = name
+    self._linear = nn.Linear(in_features, features, bias=use_bias)
+
+  @property
+  def use_bias(self):
+    """Return whether bias is used."""
+    return 'bias' in self._linear
+
+  @property
+  @override
+  def receptive_field(self) -> tuple[int, int]:
+    return (0, 0)
+
+  @override
+  def get_output_shape(self, input_shape, *, constants=None):
+    """Get output shape."""
+    if not input_shape:
+      raise ValueError(
+          f'Dense requires at least rank 3 input. Got: {input_shape=}'
+      )
+    return tuple(input_shape[:-1]) + (self.features,)
+
+  @override
+  def get_output_dtype(self, input_dtype, *, constants=None):
+    if self.compute_dtype is not None:
+      return self.compute_dtype
+    return self._param_dtype
+
+  @override
+  @mlx_types.check_layer
+  def layer(self, x, *, training: bool, constants=None):
+    compute_dtype = self.get_output_dtype(x.dtype)
+
+    def dense_fn(v):
+      y = self._linear(v.astype(compute_dtype))
+      if self.activation is not None:
+        y = self.activation(y)
+      return y
+
+    if self.use_bias or self.activation is not None:
+      return x.apply_values(dense_fn)
+    return x.apply_values_masked(dense_fn)
+
+
+class Dense(mlx_types.Stateless, spec.Dense):
+  """A basic dense layer with deferred initialization.
+
+  Matches JAX interface where in_features is inferred.
+  """
+
+  @dataclasses.dataclass(frozen=True)
+  class Config(mlx_types.SequenceLayerConfig):
+    """Dense config."""
+
+    features: int
+    use_bias: bool = True
+    activation: Callable | None = None
+    compute_dtype: mlx_types.DType | None = None
+    param_dtype: mlx_types.DType = mx.float32
+    name: str | None = None
+
+    @override
+    def make(self) -> 'Dense':
+      return Dense.from_config(self)
+
+  def __init__(
+      self,
+      *,
+      features: int,
+      use_bias: bool = True,
+      activation=None,
+      compute_dtype=None,
+      param_dtype=mx.float32,
+      name: str | None = None,
+  ):
+    """Initialize Dense."""
+    super().__init__()
+    self.features = features
+    self._use_bias = use_bias
+    self.activation = activation
+    self.compute_dtype = compute_dtype
+    self._param_dtype = param_dtype
+    self.name = name
+    self.inner = None
+
+  @property
+  @override
+  def receptive_field(self) -> tuple[int, int]:
+    return (0, 0)
+
+  def _ensure_initialized(self, in_features: int):
+    """Ensure inner _DenseEager is initialized."""
+    if self.inner is not None:
+      return
+    self.inner = _DenseEager(
+        in_features=in_features,
+        features=self.features,
+        use_bias=self._use_bias,
+        activation=self.activation,
+        compute_dtype=self.compute_dtype,
+        param_dtype=self._param_dtype,
+        name=self.name,
+    )
+
+  @override
+  def get_output_shape(self, input_shape, *, constants=None):
+    """Get output shape."""
+    if not input_shape:
+      raise ValueError(
+          f'Dense requires at least rank 3 input. Got: {input_shape=}'
+      )
+    return tuple(input_shape[:-1]) + (self.features,)
+
+  @override
+  def get_output_dtype(self, input_dtype, *, constants=None):
+    if self.compute_dtype is not None:
+      return self.compute_dtype
+    return self._param_dtype
+
+  @override
+  @mlx_types.check_layer
+  def layer(self, x, *, training: bool, constants=None):
+    self._ensure_initialized(x.shape[-1])
+    assert self.inner is not None
+    return self.inner.layer(x, training=training, constants=constants)
+
+  @classmethod
+  def from_config(cls, config):
+    """Create Dense from config."""
+    compute_dtype = getattr(config, 'compute_dtype', None)
+    if compute_dtype is not None:
+      compute_dtype = _to_mx_dtype(compute_dtype)
+    return cls(
+        features=config.features,
+        use_bias=config.use_bias,
+        activation=init_mapping.map_activation(config.activation),
+        compute_dtype=compute_dtype,
+        param_dtype=_to_mx_dtype(config.param_dtype),
+        name=config.name,
+    )
+
+
+# pylint: disable=too-many-instance-attributes
+class EinsumDense(mlx_types.Stateless, spec.EinsumDense):
+  """Dense layer using Einstein summation notation."""
+
+  @dataclasses.dataclass(frozen=True)
+  class Config(mlx_types.SequenceLayerConfig):
+    """MLX-native configuration for EinsumDense."""
+
+    equation: str = ''
+    output_shape: tuple[int | None, ...] = ()
+    bias_axes: str = ''
+    activation: Callable | None = None
+    compute_dtype: mlx_types.DType | None = None
+    param_dtype: mlx_types.DType = mx.float32
+    name: str | None = None
+
+    def __post_init__(self):
+      object.__setattr__(self, 'output_shape', tuple(self.output_shape))
+
+    @override
+    def make(self) -> 'EinsumDense':
+      return EinsumDense.from_config(self)
+
+  def __init__(
+      self,
+      *,
+      equation,
+      output_shape,
+      bias_axes='',
+      activation=None,
+      compute_dtype=None,
+      param_dtype=mx.float32,
+      name: str | None = None,
+  ):
+    """Initialize EinsumDense."""
+    super().__init__()
+    self._equation = equation
+    self._output_shape_spec = tuple(output_shape)
+    self._bias_axes = bias_axes
+    self._activation = activation
+    self._compute_dtype = compute_dtype
+    self._param_dtype = param_dtype
+    self.name = name
+    self.kernel = None
+    self.bias = None
+    self._initialized = False
+    self._resolved_output_shape = None
+
+  @property
+  @override
+  def receptive_field(self) -> tuple[int, int]:
+    return (0, 0)
+
+  def _ensure_initialized(self, input_shape):
+    """Ensure parameters are initialized."""
+    if self._initialized:
+      return
+    output_shape, kernel_shape, bias_shape = _compute_shapes(
+        self._equation, input_shape, self._output_shape_spec, self._bias_axes
+    )
+    self._resolved_output_shape = output_shape
+    self.kernel = mx.zeros(kernel_shape, dtype=self._param_dtype)
+    if bias_shape is not None:
+      self.bias = mx.zeros(bias_shape, dtype=self._param_dtype)
+    self._initialized = True
+
+  @override
+  def get_output_shape(self, input_shape, *, constants=None):
+    """Get output shape."""
+    output_shape, _, _ = _compute_shapes(
+        self._equation, input_shape, self._output_shape_spec, self._bias_axes
+    )
+    return output_shape
+
+  @override
+  def get_output_dtype(self, input_dtype, *, constants=None):
+    if self._compute_dtype is not None:
+      return self._compute_dtype
+    return self._param_dtype
+
+  @override
+  @mlx_types.check_layer
+  def layer(self, x, *, training: bool, constants=None):
+    self._ensure_initialized(x.channel_shape)
+    compute_dtype = self.get_output_dtype(x.dtype)
+
+    def einsum_fn(v):
+      y = mx.einsum(self._equation, v.astype(compute_dtype), self.kernel)
+      if self.bias is not None:
+        y = y + self.bias
+      if self._activation is not None:
+        y = self._activation(y)
+      return y
+
+    if self.bias is not None or self._activation is not None:
+      return x.apply_values(einsum_fn)
+    return x.apply_values_masked(einsum_fn)
+
+  @classmethod
+  def from_config(cls, config):
+    """Create EinsumDense from config."""
+    compute_dtype = getattr(config, 'compute_dtype', None)
+    if compute_dtype is not None:
+      compute_dtype = _to_mx_dtype(compute_dtype)
+    return cls(
+        equation=config.equation,
+        output_shape=config.output_shape,
+        bias_axes=config.bias_axes,
+        activation=init_mapping.map_activation(config.activation),
+        compute_dtype=compute_dtype,
+        param_dtype=_to_mx_dtype(config.param_dtype),
+        name=config.name,
+    )
+
+
+def _parse_equation(equation):
+  """Parse einsum equation of form '...ab,bc->...ac'."""
+  if '->' not in equation:
+    raise ValueError(f'equation is not valid for EinsumDense: {equation}')
+  left, output_spec = equation.split('->')
+  input_spec, kernel_spec = left.split(',')
+  if not input_spec.startswith('...') or not output_spec.startswith('...'):
+    raise ValueError('Equation must be of the form "...X,Y->...Z".')
+  if 3 + len(set(input_spec[3:])) != len(input_spec):
+    raise ValueError(
+        f'Equation {input_spec=} must not contain duplicate variables.'
+    )
+  if 3 + len(set(output_spec[3:])) != len(output_spec):
+    raise ValueError(
+        f'Equation {output_spec=} must not contain duplicate variables.'
+    )
+  return input_spec, kernel_spec, output_spec
+
+
+def _compute_shapes(equation, input_shape, output_shape_spec, bias_axes):
+  """Compute kernel_shape and bias_shape from equation and shapes."""
+  input_spec, kernel_spec, output_spec = _parse_equation(equation)
+  in_spec = input_spec[3:]
+  out_spec = output_spec[3:]
+
+  if len(in_spec) != len(input_shape):
+    raise ValueError(f'Equation {in_spec=} does not match {input_shape=} rank.')
+
+  input_dims = {d: input_shape[i] for i, d in enumerate(in_spec)}
+  output_shape = list(output_shape_spec)
+  if len(out_spec) != len(output_shape):
+    raise ValueError(f'Equation {out_spec=} does not match {output_shape=}.')
+
+  for i, d in enumerate(out_spec):
+    if output_shape[i] is None:
+      output_shape[i] = input_dims[d]
+    elif d in input_dims and output_shape[i] != input_dims[d]:
+      raise ValueError(
+          f'Inconsistent dimension {d=}. {output_shape=} vs {input_shape=}'
+      )
+
+  output_dim_map = {d: output_shape[i] for i, d in enumerate(out_spec)}
+
+  kernel_shape = []
+  for d in kernel_spec:
+    if d in input_dims:
+      kernel_shape.append(input_dims[d])
+    elif d in output_dim_map:
+      kernel_shape.append(output_dim_map[d])
+    else:
+      raise ValueError(f"Weight dimension '{d}' not in input or output spec.")
+
+  if bias_axes:
+    first_bias_loc = min(out_spec.find(c) for c in bias_axes)
+    bias_out_spec = out_spec[first_bias_loc:]
+    bias_shape = [
+        output_dim_map[c] if c in bias_axes else 1 for c in bias_out_spec
+    ]
+  else:
+    bias_shape = None
+
+  return tuple(output_shape), tuple(kernel_shape), bias_shape

--- a/sequence_layers/mlx/dense.py
+++ b/sequence_layers/mlx/dense.py
@@ -6,119 +6,39 @@ from typing import Callable, override
 from mlx import nn
 import mlx.core as mx
 
-from sequence_layers.mlx import init_mapping
-from sequence_layers.mlx import types as mlx_types
-from sequence_layers.mlx.init_mapping import _to_mx_dtype
+from sequence_layers.mlx import types
+from sequence_layers.mlx.simple import _to_mx_dtype
 from sequence_layers.specs import dense as spec
 
 
-class _DenseEager(mlx_types.Stateless):
-  """A basic dense layer backed by mlx.nn.Linear.
-
-  Requires in_features at initialization.
-  """
-
-  def __init__(
-      self,
-      *,
-      in_features: int,
-      features: int,
-      use_bias: bool = True,
-      activation=None,
-      compute_dtype=None,
-      param_dtype=mx.float32,
-      name: str | None = None,
-  ):
-    """Initialize _DenseEager."""
-    super().__init__()
-    self.features = features
-    self.activation = activation
-    self.compute_dtype = compute_dtype
-    self._param_dtype = param_dtype
-    self.name = name
-    self._linear = nn.Linear(in_features, features, bias=use_bias)
-
-  @property
-  def use_bias(self):
-    """Return whether bias is used."""
-    return 'bias' in self._linear
-
-  @property
-  @override
-  def receptive_field(self) -> tuple[int, int]:
-    return (0, 0)
-
-  @override
-  def get_output_shape(self, input_shape, *, constants=None):
-    """Get output shape."""
-    if not input_shape:
-      raise ValueError(
-          f'Dense requires at least rank 3 input. Got: {input_shape=}'
-      )
-    return tuple(input_shape[:-1]) + (self.features,)
-
-  @override
-  def get_output_dtype(self, input_dtype, *, constants=None):
-    if self.compute_dtype is not None:
-      return self.compute_dtype
-    return self._param_dtype
-
-  @override
-  @mlx_types.check_layer
-  def layer(self, x, *, training: bool, constants=None):
-    compute_dtype = self.get_output_dtype(x.dtype)
-
-    def dense_fn(v):
-      y = self._linear(v.astype(compute_dtype))
-      if self.activation is not None:
-        y = self.activation(y)
-      return y
-
-    if self.use_bias or self.activation is not None:
-      return x.apply_values(dense_fn)
-    return x.apply_values_masked(dense_fn)
-
-
-class Dense(mlx_types.Stateless, spec.Dense):
+class Dense(types.Stateless, spec.Dense):
   """A basic dense layer with deferred initialization.
 
-  Matches JAX interface where in_features is inferred.
+  Matches JAX interface where in_features is inferred on first call.
   """
 
   @dataclasses.dataclass(frozen=True)
-  class Config(mlx_types.SequenceLayerConfig):
+  class Config(types.SequenceLayerConfig, spec.Dense.Config):
     """Dense config."""
 
     features: int
     use_bias: bool = True
     activation: Callable | None = None
-    compute_dtype: mlx_types.DType | None = None
-    param_dtype: mlx_types.DType = mx.float32
+    compute_dtype: types.DType | None = None
+    param_dtype: types.DType = mx.float32
     name: str | None = None
 
     @override
     def make(self) -> 'Dense':
-      return Dense.from_config(self)
+      return Dense(self)
 
-  def __init__(
-      self,
-      *,
-      features: int,
-      use_bias: bool = True,
-      activation=None,
-      compute_dtype=None,
-      param_dtype=mx.float32,
-      name: str | None = None,
-  ):
+  def __init__(self, config: Config):
     """Initialize Dense."""
     super().__init__()
-    self.features = features
-    self._use_bias = use_bias
-    self.activation = activation
-    self.compute_dtype = compute_dtype
-    self._param_dtype = param_dtype
-    self.name = name
-    self.inner = None
+    self.config = config
+    self._compute_dtype = _to_mx_dtype(config.compute_dtype)
+    self._param_dtype = _to_mx_dtype(config.param_dtype)
+    self._linear = None
 
   @property
   @override
@@ -126,17 +46,11 @@ class Dense(mlx_types.Stateless, spec.Dense):
     return (0, 0)
 
   def _ensure_initialized(self, in_features: int):
-    """Ensure inner _DenseEager is initialized."""
-    if self.inner is not None:
+    """Ensure nn.Linear is initialized on first call."""
+    if self._linear is not None:
       return
-    self.inner = _DenseEager(
-        in_features=in_features,
-        features=self.features,
-        use_bias=self._use_bias,
-        activation=self.activation,
-        compute_dtype=self.compute_dtype,
-        param_dtype=self._param_dtype,
-        name=self.name,
+    self._linear = nn.Linear(
+        in_features, self.config.features, bias=self.config.use_bias
     )
 
   @override
@@ -146,51 +60,51 @@ class Dense(mlx_types.Stateless, spec.Dense):
       raise ValueError(
           f'Dense requires at least rank 3 input. Got: {input_shape=}'
       )
-    return tuple(input_shape[:-1]) + (self.features,)
+    return tuple(input_shape[:-1]) + (self.config.features,)
 
   @override
   def get_output_dtype(self, input_dtype, *, constants=None):
-    if self.compute_dtype is not None:
-      return self.compute_dtype
+    if self._compute_dtype is not None:
+      return self._compute_dtype
+    assert self._param_dtype is not None
     return self._param_dtype
 
   @override
-  @mlx_types.check_layer
-  def layer(self, x, *, training: bool, constants=None):
+  @types.check_layer
+  def layer(  # pyrefly: ignore[missing-override-decorator]
+      self, x, *, training: bool, constants=None
+  ):
+    if x.ndim < 3:
+      raise ValueError(f'Dense requires at least rank 3 input. Got: {x.shape=}')
     self._ensure_initialized(x.shape[-1])
-    assert self.inner is not None
-    return self.inner.layer(x, training=training, constants=constants)
+    assert self._linear is not None
+    activation = self.config.activation
+    compute_dtype = self.get_output_dtype(x.dtype)
 
-  @classmethod
-  def from_config(cls, config):
-    """Create Dense from config."""
-    compute_dtype = getattr(config, 'compute_dtype', None)
-    if compute_dtype is not None:
-      compute_dtype = _to_mx_dtype(compute_dtype)
-    return cls(
-        features=config.features,
-        use_bias=config.use_bias,
-        activation=init_mapping.map_activation(config.activation),
-        compute_dtype=compute_dtype,
-        param_dtype=_to_mx_dtype(config.param_dtype),
-        name=config.name,
-    )
+    def dense_fn(v):
+      y = self._linear(v.astype(compute_dtype))
+      if activation is not None:
+        y = activation(y)
+      return y
+
+    if self.config.use_bias or activation is not None:
+      return x.apply_values(dense_fn)
+    return x.apply_values_masked(dense_fn)
 
 
-# pylint: disable=too-many-instance-attributes
-class EinsumDense(mlx_types.Stateless, spec.EinsumDense):
+class EinsumDense(types.Stateless, spec.EinsumDense):
   """Dense layer using Einstein summation notation."""
 
   @dataclasses.dataclass(frozen=True)
-  class Config(mlx_types.SequenceLayerConfig):
+  class Config(types.SequenceLayerConfig, spec.EinsumDense.Config):
     """MLX-native configuration for EinsumDense."""
 
     equation: str = ''
     output_shape: tuple[int | None, ...] = ()
     bias_axes: str = ''
     activation: Callable | None = None
-    compute_dtype: mlx_types.DType | None = None
-    param_dtype: mlx_types.DType = mx.float32
+    compute_dtype: types.DType | None = None
+    param_dtype: types.DType = mx.float32
     name: str | None = None
 
     def __post_init__(self):
@@ -198,28 +112,14 @@ class EinsumDense(mlx_types.Stateless, spec.EinsumDense):
 
     @override
     def make(self) -> 'EinsumDense':
-      return EinsumDense.from_config(self)
+      return EinsumDense(self)
 
-  def __init__(
-      self,
-      *,
-      equation,
-      output_shape,
-      bias_axes='',
-      activation=None,
-      compute_dtype=None,
-      param_dtype=mx.float32,
-      name: str | None = None,
-  ):
+  def __init__(self, config: Config):
     """Initialize EinsumDense."""
     super().__init__()
-    self._equation = equation
-    self._output_shape_spec = tuple(output_shape)
-    self._bias_axes = bias_axes
-    self._activation = activation
-    self._compute_dtype = compute_dtype
-    self._param_dtype = param_dtype
-    self.name = name
+    self.config = config
+    self._compute_dtype = _to_mx_dtype(config.compute_dtype)
+    self._param_dtype = _to_mx_dtype(config.param_dtype)
     self.kernel = None
     self.bias = None
     self._initialized = False
@@ -235,7 +135,10 @@ class EinsumDense(mlx_types.Stateless, spec.EinsumDense):
     if self._initialized:
       return
     output_shape, kernel_shape, bias_shape = _compute_shapes(
-        self._equation, input_shape, self._output_shape_spec, self._bias_axes
+        self.config.equation,
+        input_shape,
+        self.config.output_shape,
+        self.config.bias_axes,
     )
     self._resolved_output_shape = output_shape
     self.kernel = mx.zeros(kernel_shape, dtype=self._param_dtype)
@@ -247,7 +150,10 @@ class EinsumDense(mlx_types.Stateless, spec.EinsumDense):
   def get_output_shape(self, input_shape, *, constants=None):
     """Get output shape."""
     output_shape, _, _ = _compute_shapes(
-        self._equation, input_shape, self._output_shape_spec, self._bias_axes
+        self.config.equation,
+        input_shape,
+        self.config.output_shape,
+        self.config.bias_axes,
     )
     return output_shape
 
@@ -255,41 +161,29 @@ class EinsumDense(mlx_types.Stateless, spec.EinsumDense):
   def get_output_dtype(self, input_dtype, *, constants=None):
     if self._compute_dtype is not None:
       return self._compute_dtype
+    assert self._param_dtype is not None
     return self._param_dtype
 
   @override
-  @mlx_types.check_layer
-  def layer(self, x, *, training: bool, constants=None):
+  @types.check_layer
+  def layer(  # pyrefly: ignore[missing-override-decorator]
+      self, x, *, training: bool, constants=None
+  ):
     self._ensure_initialized(x.channel_shape)
     compute_dtype = self.get_output_dtype(x.dtype)
+    activation = self.config.activation
 
     def einsum_fn(v):
-      y = mx.einsum(self._equation, v.astype(compute_dtype), self.kernel)
+      y = mx.einsum(self.config.equation, v.astype(compute_dtype), self.kernel)
       if self.bias is not None:
         y = y + self.bias
-      if self._activation is not None:
-        y = self._activation(y)
+      if activation is not None:
+        y = activation(y)
       return y
 
-    if self.bias is not None or self._activation is not None:
+    if self.bias is not None or activation is not None:
       return x.apply_values(einsum_fn)
     return x.apply_values_masked(einsum_fn)
-
-  @classmethod
-  def from_config(cls, config):
-    """Create EinsumDense from config."""
-    compute_dtype = getattr(config, 'compute_dtype', None)
-    if compute_dtype is not None:
-      compute_dtype = _to_mx_dtype(compute_dtype)
-    return cls(
-        equation=config.equation,
-        output_shape=config.output_shape,
-        bias_axes=config.bias_axes,
-        activation=init_mapping.map_activation(config.activation),
-        compute_dtype=compute_dtype,
-        param_dtype=_to_mx_dtype(config.param_dtype),
-        name=config.name,
-    )
 
 
 def _parse_equation(equation):

--- a/sequence_layers/mlx/dense.py
+++ b/sequence_layers/mlx/dense.py
@@ -19,7 +19,14 @@ class Dense(types.Stateless, spec.Dense):
 
   @dataclasses.dataclass(frozen=True)
   class Config(spec.Dense.Config):
+    """Dense config."""
+
+    features: int
+    use_bias: bool = True
+    activation: Callable | None = None
+    compute_dtype: types.DType | None = None
     param_dtype: types.DType = mx.float32
+    name: str | None = None
 
     @override
     def make(self) -> 'Dense':
@@ -94,7 +101,15 @@ class EinsumDense(types.Stateless, spec.EinsumDense):
 
   @dataclasses.dataclass(frozen=True)
   class Config(spec.EinsumDense.Config):
+    """MLX-native configuration for EinsumDense."""
+
+    equation: str = ''
+    output_shape: tuple[int | None, ...] = ()
+    bias_axes: str = ''
+    activation: Callable | None = None
+    compute_dtype: types.DType | None = None
     param_dtype: types.DType = mx.float32
+    name: str | None = None
 
     def __post_init__(self):
       object.__setattr__(self, 'output_shape', tuple(self.output_shape))

--- a/sequence_layers/mlx/dense.py
+++ b/sequence_layers/mlx/dense.py
@@ -18,26 +18,23 @@ class Dense(types.Stateless, spec.Dense):
   """
 
   @dataclasses.dataclass(frozen=True)
-  class Config(types.SequenceLayerConfig, spec.Dense.Config):
-    """Dense config."""
-
-    features: int
-    use_bias: bool = True
-    activation: Callable | None = None
-    compute_dtype: types.DType | None = None
+  class Config(spec.Dense.Config):
     param_dtype: types.DType = mx.float32
-    name: str | None = None
 
     @override
     def make(self) -> 'Dense':
-      return Dense(self)
+      return Dense.from_config(self)
 
-  def __init__(self, config: Config):
+  @classmethod
+  def from_config(cls, config: spec.Dense.Config) -> 'Dense':
+    return cls(config)
+
+  def __init__(self, config: spec.Dense.Config):
     """Initialize Dense."""
     super().__init__()
     self.config = config
     self._compute_dtype = _to_mx_dtype(config.compute_dtype)
-    self._param_dtype = _to_mx_dtype(config.param_dtype)
+    self._param_dtype = _to_mx_dtype(config.param_dtype) or mx.float32
     self._linear = None
 
   @property
@@ -96,30 +93,26 @@ class EinsumDense(types.Stateless, spec.EinsumDense):
   """Dense layer using Einstein summation notation."""
 
   @dataclasses.dataclass(frozen=True)
-  class Config(types.SequenceLayerConfig, spec.EinsumDense.Config):
-    """MLX-native configuration for EinsumDense."""
-
-    equation: str = ''
-    output_shape: tuple[int | None, ...] = ()
-    bias_axes: str = ''
-    activation: Callable | None = None
-    compute_dtype: types.DType | None = None
+  class Config(spec.EinsumDense.Config):
     param_dtype: types.DType = mx.float32
-    name: str | None = None
 
     def __post_init__(self):
       object.__setattr__(self, 'output_shape', tuple(self.output_shape))
 
     @override
     def make(self) -> 'EinsumDense':
-      return EinsumDense(self)
+      return EinsumDense.from_config(self)
 
-  def __init__(self, config: Config):
+  @classmethod
+  def from_config(cls, config: spec.EinsumDense.Config) -> 'EinsumDense':
+    return cls(config)
+
+  def __init__(self, config: spec.EinsumDense.Config):
     """Initialize EinsumDense."""
     super().__init__()
     self.config = config
     self._compute_dtype = _to_mx_dtype(config.compute_dtype)
-    self._param_dtype = _to_mx_dtype(config.param_dtype)
+    self._param_dtype = _to_mx_dtype(config.param_dtype) or mx.float32
     self.kernel = None
     self.bias = None
     self._initialized = False

--- a/sequence_layers/mlx/dense.py
+++ b/sequence_layers/mlx/dense.py
@@ -12,7 +12,7 @@ from sequence_layers.mlx.simple import _to_mx_dtype
 from sequence_layers.specs import dense as spec
 
 
-class Dense(types.Stateless, spec.Dense):
+class Dense(types.Stateless, spec.Dense[types.Sequence, types.ShapeDType]):
   """A basic dense layer with deferred initialization.
 
   Matches JAX interface where in_features is inferred on first call.
@@ -35,6 +35,7 @@ class Dense(types.Stateless, spec.Dense):
 
   @classmethod
   def from_config(cls, config: spec.Dense.Config) -> 'Dense':
+    """Creates a Dense layer from a spec Config."""
     mlx_config = cls.Config(
         features=config.features,
         use_bias=config.use_bias,
@@ -72,6 +73,7 @@ class Dense(types.Stateless, spec.Dense):
       )
     self._compute_dtype = _to_mx_dtype(self.config.compute_dtype)
     self._param_dtype = _to_mx_dtype(self.config.param_dtype) or mx.float32
+    self.activation = init_mapping.map_activation(self.config.activation)
     self._linear = None
     if in_features is not None:
       self._ensure_initialized(in_features)
@@ -114,7 +116,7 @@ class Dense(types.Stateless, spec.Dense):
       raise ValueError(f'Dense requires at least rank 3 input. Got: {x.shape=}')
     self._ensure_initialized(x.shape[-1])
     assert self._linear is not None
-    activation = self.config.activation
+    activation = self.activation
     compute_dtype = self.get_output_dtype(x.dtype)
 
     def dense_fn(v):
@@ -128,7 +130,9 @@ class Dense(types.Stateless, spec.Dense):
     return x.apply_values_masked(dense_fn)
 
 
-class EinsumDense(types.Stateless, spec.EinsumDense):
+class EinsumDense(
+    types.Stateless, spec.EinsumDense[types.Sequence, types.ShapeDType]
+):
   """Dense layer using Einstein summation notation."""
 
   @dataclasses.dataclass(frozen=True)
@@ -152,6 +156,7 @@ class EinsumDense(types.Stateless, spec.EinsumDense):
 
   @classmethod
   def from_config(cls, config: spec.EinsumDense.Config) -> 'EinsumDense':
+    """Creates an EinsumDense layer from a spec Config."""
     mlx_config = cls.Config(
         equation=config.equation,
         output_shape=tuple(config.output_shape),
@@ -191,6 +196,7 @@ class EinsumDense(types.Stateless, spec.EinsumDense):
       )
     self._compute_dtype = _to_mx_dtype(self.config.compute_dtype)
     self._param_dtype = _to_mx_dtype(self.config.param_dtype) or mx.float32
+    self.activation = init_mapping.map_activation(self.config.activation)
     self.kernel = None
     self.bias = None
     self._initialized = False
@@ -242,7 +248,7 @@ class EinsumDense(types.Stateless, spec.EinsumDense):
   ):
     self._ensure_initialized(x.channel_shape)
     compute_dtype = self.get_output_dtype(x.dtype)
-    activation = self.config.activation
+    activation = self.activation
 
     def einsum_fn(v):
       y = mx.einsum(self.config.equation, v.astype(compute_dtype), self.kernel)

--- a/sequence_layers/mlx/dense.py
+++ b/sequence_layers/mlx/dense.py
@@ -18,7 +18,7 @@ class Dense(types.Stateless, spec.Dense):
   """
 
   @dataclasses.dataclass(frozen=True)
-  class Config(spec.Dense.Config):
+  class Config(types.SequenceLayerConfig, spec.Dense.Config):
     """Dense config."""
 
     features: int
@@ -30,18 +30,46 @@ class Dense(types.Stateless, spec.Dense):
 
     @override
     def make(self) -> 'Dense':
-      return Dense.from_config(self)
+      return Dense(self)
 
   @classmethod
   def from_config(cls, config: spec.Dense.Config) -> 'Dense':
-    return cls(config)
+    mlx_config = cls.Config(
+        features=config.features,
+        use_bias=config.use_bias,
+        activation=config.activation,
+        compute_dtype=config.compute_dtype,
+        param_dtype=config.param_dtype or mx.float32,
+        name=config.name,
+    )
+    return cls(mlx_config)
 
-  def __init__(self, config: spec.Dense.Config):
+  def __init__(
+      self,
+      config: Config | None = None,
+      *,
+      features: int | None = None,
+      use_bias: bool = True,
+      activation=None,
+      compute_dtype=None,
+      param_dtype=mx.float32,
+  ):
     """Initialize Dense."""
     super().__init__()
-    self.config = config
-    self._compute_dtype = _to_mx_dtype(config.compute_dtype)
-    self._param_dtype = _to_mx_dtype(config.param_dtype) or mx.float32
+    if config is not None:
+      self.config = config
+    else:
+      if features is None:
+        raise ValueError('Must provide either config or features')
+      self.config = self.Config(
+          features=features,
+          use_bias=use_bias,
+          activation=activation,
+          compute_dtype=compute_dtype,
+          param_dtype=param_dtype,
+      )
+    self._compute_dtype = _to_mx_dtype(self.config.compute_dtype)
+    self._param_dtype = _to_mx_dtype(self.config.param_dtype) or mx.float32
     self._linear = None
 
   @property
@@ -100,11 +128,11 @@ class EinsumDense(types.Stateless, spec.EinsumDense):
   """Dense layer using Einstein summation notation."""
 
   @dataclasses.dataclass(frozen=True)
-  class Config(spec.EinsumDense.Config):
+  class Config(types.SequenceLayerConfig, spec.EinsumDense.Config):
     """MLX-native configuration for EinsumDense."""
 
-    equation: str = ''
-    output_shape: tuple[int | None, ...] = ()
+    equation: str
+    output_shape: tuple[int | None, ...]
     bias_axes: str = ''
     activation: Callable | None = None
     compute_dtype: types.DType | None = None
@@ -116,18 +144,49 @@ class EinsumDense(types.Stateless, spec.EinsumDense):
 
     @override
     def make(self) -> 'EinsumDense':
-      return EinsumDense.from_config(self)
+      return EinsumDense(self)
 
   @classmethod
   def from_config(cls, config: spec.EinsumDense.Config) -> 'EinsumDense':
-    return cls(config)
+    mlx_config = cls.Config(
+        equation=config.equation,
+        output_shape=tuple(config.output_shape),
+        bias_axes=config.bias_axes,
+        activation=config.activation,
+        compute_dtype=config.compute_dtype,
+        param_dtype=config.param_dtype or mx.float32,
+        name=config.name,
+    )
+    return cls(mlx_config)
 
-  def __init__(self, config: spec.EinsumDense.Config):
+  def __init__(
+      self,
+      config: Config | None = None,
+      *,
+      equation: str | None = None,
+      output_shape: tuple[int | None, ...] = (),
+      bias_axes: str = '',
+      activation=None,
+      compute_dtype=None,
+      param_dtype=mx.float32,
+  ):
     """Initialize EinsumDense."""
     super().__init__()
-    self.config = config
-    self._compute_dtype = _to_mx_dtype(config.compute_dtype)
-    self._param_dtype = _to_mx_dtype(config.param_dtype) or mx.float32
+    if config is not None:
+      self.config = config
+    else:
+      if equation is None:
+        raise ValueError('Must provide either config or equation')
+      self.config = self.Config(
+          equation=equation,
+          output_shape=output_shape,
+          bias_axes=bias_axes,
+          activation=activation,
+          compute_dtype=compute_dtype,
+          param_dtype=param_dtype,
+      )
+    self._compute_dtype = _to_mx_dtype(self.config.compute_dtype)
+    self._param_dtype = _to_mx_dtype(self.config.param_dtype) or mx.float32
     self.kernel = None
     self.bias = None
     self._initialized = False

--- a/sequence_layers/mlx/dense.py
+++ b/sequence_layers/mlx/dense.py
@@ -6,6 +6,7 @@ from typing import Callable, override
 from mlx import nn
 import mlx.core as mx
 
+from sequence_layers.mlx import init_mapping
 from sequence_layers.mlx import types
 from sequence_layers.mlx.simple import _to_mx_dtype
 from sequence_layers.specs import dense as spec
@@ -37,7 +38,7 @@ class Dense(types.Stateless, spec.Dense):
     mlx_config = cls.Config(
         features=config.features,
         use_bias=config.use_bias,
-        activation=config.activation,
+        activation=init_mapping.map_activation(config.activation),
         compute_dtype=config.compute_dtype,
         param_dtype=config.param_dtype or mx.float32,
         name=config.name,
@@ -49,6 +50,7 @@ class Dense(types.Stateless, spec.Dense):
       config: Config | None = None,
       *,
       features: int | None = None,
+      in_features: int | None = None,
       use_bias: bool = True,
       activation=None,
       compute_dtype=None,
@@ -71,6 +73,8 @@ class Dense(types.Stateless, spec.Dense):
     self._compute_dtype = _to_mx_dtype(self.config.compute_dtype)
     self._param_dtype = _to_mx_dtype(self.config.param_dtype) or mx.float32
     self._linear = None
+    if in_features is not None:
+      self._ensure_initialized(in_features)
 
   @property
   @override
@@ -152,7 +156,7 @@ class EinsumDense(types.Stateless, spec.EinsumDense):
         equation=config.equation,
         output_shape=tuple(config.output_shape),
         bias_axes=config.bias_axes,
-        activation=config.activation,
+        activation=init_mapping.map_activation(config.activation),
         compute_dtype=config.compute_dtype,
         param_dtype=config.param_dtype or mx.float32,
         name=config.name,

--- a/sequence_layers/mlx/dense_test.py
+++ b/sequence_layers/mlx/dense_test.py
@@ -1,0 +1,33 @@
+"""Tests for Dense MLX sequence layers."""
+
+from absl.testing import absltest
+from mlx import nn
+
+from sequence_layers.mlx import dense
+from sequence_layers.mlx import test_utils
+from sequence_layers.specs import dense_behaviors as spec
+
+
+class DenseTest(test_utils.SequenceLayerTest, spec.DenseTest):
+  """Test behavior of Dense layer."""
+
+  def test_eager_layer(self):
+    """Test DenseEager which is not in the spec."""
+    layer = dense._DenseEager(in_features=4, features=8)
+    x = self.random_sequence(2, 3, 4)
+    self.verify_contract(layer, x)
+
+  def test_activation(self):
+    """Test activation in Dense."""
+    # Test with deferred Dense
+    layer = dense.Dense(features=8, activation=nn.relu)
+    x = self.random_sequence(2, 3, 4)
+    self.verify_contract(layer, x)
+
+
+class EinsumDenseTest(test_utils.SequenceLayerTest, spec.EinsumDenseTest):
+  """Test behavior of EinsumDense layer."""
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/sequence_layers/mlx/dense_test.py
+++ b/sequence_layers/mlx/dense_test.py
@@ -11,17 +11,11 @@ from sequence_layers.specs import dense_behaviors as spec
 class DenseTest(test_utils.SequenceLayerTest, spec.DenseTest):
   """Test behavior of Dense layer."""
 
-  def test_eager_layer(self):
-    """Test DenseEager which is not in the spec."""
-    layer = dense._DenseEager(in_features=4, features=8)
-    x = self.random_sequence(2, 3, 4)
-    self.verify_contract(layer, x)
-
   def test_activation(self):
     """Test activation in Dense."""
-    # Test with deferred Dense
-    layer = dense.Dense(features=8, activation=nn.relu)
+    layer = dense.Dense.Config(features=8, activation=nn.relu).make()
     x = self.random_sequence(2, 3, 4)
+    layer = self.init_layer(layer, x)
     self.verify_contract(layer, x)
 
 

--- a/sequence_layers/mlx/dense_test.py
+++ b/sequence_layers/mlx/dense_test.py
@@ -15,8 +15,9 @@ class DenseTest(test_utils.SequenceLayerTest, spec.DenseTest):
     """Test activation in Dense."""
     layer = dense.Dense.Config(features=8, activation=nn.relu).make()
     x = self.random_sequence(2, 3, 4)
+    # pyrefly: ignore[bad-argument-type]
     layer = self.init_layer(layer, x)
-    self.verify_contract(layer, x)
+    self.verify_contract(layer, x)  # pyrefly: ignore[bad-argument-type]
 
 
 class EinsumDenseTest(test_utils.SequenceLayerTest, spec.EinsumDenseTest):

--- a/sequence_layers/mlx/init_mapping.py
+++ b/sequence_layers/mlx/init_mapping.py
@@ -1,0 +1,232 @@
+"""Mapping JAX/Flax initializers and activations to MLX equivalents."""
+
+import functools
+import math
+
+import jax
+import jax.numpy as jnp
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+from flax.linen import initializers as flax_init
+
+
+def _variance_scaling(key, shape, dtype, mode, distribution, fan_in, fan_out):
+  """Variance scaling initializer core logic."""
+  dtype = _to_mx_dtype(dtype)
+  if mode == 'fan_in':
+    denominator = max(fan_in, 1)
+  elif mode == 'fan_out':
+    denominator = max(fan_out, 1)
+  elif mode == 'fan_avg':
+    denominator = max((fan_in + fan_out) / 2.0, 1)
+  else:
+    raise ValueError(f'Unknown mode: {mode}')
+
+  variance = 1.0 / denominator
+  if distribution == 'truncated_normal':
+    stddev = math.sqrt(variance) / 0.87962566103423978
+    return (
+        mx.random.truncated_normal(-2.0, 2.0, shape=shape, key=key).astype(
+            dtype
+        )
+        * stddev
+    )
+  elif distribution == 'normal':
+    return mx.random.normal(shape=shape, key=key).astype(dtype) * math.sqrt(
+        variance
+    )
+  elif distribution == 'uniform':
+    limit = math.sqrt(3.0 * variance)
+    return mx.random.uniform(-limit, limit, shape=shape, key=key).astype(dtype)
+  else:
+    raise ValueError(f'Unknown distribution: {distribution}')
+
+
+def _compute_fans(shape):
+  """Compute fan_in and fan_out for a weight shape."""
+  if len(shape) < 1:
+    fan_in = fan_out = 1
+  elif len(shape) == 1:
+    fan_in = fan_out = shape[0]
+  elif len(shape) == 2:
+    fan_in, fan_out = shape
+  else:
+    # Conv kernels: last two dims are (fan_in, fan_out), rest are spatial.
+    receptive_field_size = 1
+    for s in shape[:-2]:
+      receptive_field_size *= s
+    fan_in = shape[-2] * receptive_field_size
+    fan_out = shape[-1] * receptive_field_size
+  return fan_in, fan_out
+
+
+def _make_variance_scaling_init(mode, distribution):
+  """Create an MLX variance scaling initializer."""
+
+  def init_fn(key, shape, dtype=mx.float32):
+    fan_in, fan_out = _compute_fans(shape)
+    return _variance_scaling(
+        key, shape, dtype, mode, distribution, fan_in, fan_out
+    )
+
+  return init_fn
+
+
+def _to_mx_dtype(dtype):
+  """Convert any dtype (JAX, numpy, MLX) to an MLX dtype."""
+  if isinstance(dtype, mx.Dtype):
+    return dtype
+  name = getattr(dtype, '__name__', '') or str(dtype)
+  mapping = {
+      'float32': mx.float32,
+      'float16': mx.float16,
+      'bfloat16': mx.bfloat16,
+      'float64': mx.float32,  # MLX lacks float64.
+      'int32': mx.int32,
+      'int64': mx.int32,  # MLX lacks int64.
+      'int16': mx.int16,
+      'int8': mx.int8,
+      'uint8': mx.uint8,
+      'uint32': mx.uint32,
+      'bool': mx.bool_,
+      'bool_': mx.bool_,
+      'complex64': mx.complex64,
+  }
+  for key, val in mapping.items():
+    if key in name:
+      return val
+  return mx.float32
+
+
+def _zeros_init(key, shape, dtype=mx.float32):
+  del key
+  return mx.zeros(shape, dtype=_to_mx_dtype(dtype))
+
+
+def _ones_init(key, shape, dtype=mx.float32):
+  del key
+  return mx.ones(shape, dtype=_to_mx_dtype(dtype))
+
+
+def _normal_init(stddev=0.01):
+  def init_fn(key, shape, dtype=mx.float32):
+    dtype = _to_mx_dtype(dtype)
+    return mx.random.normal(shape=shape, key=key).astype(dtype) * stddev
+
+  return init_fn
+
+
+def map_initializer(jax_init):
+  """Convert a JAX/Flax initializer to an MLX-compatible initializer.
+
+  Args:
+    jax_init: A JAX/Flax initializer function.
+
+  Returns:
+    An MLX initializer function with signature (key, shape, dtype).
+  """
+  if jax_init is None:
+    return None
+
+  # Check for common Flax initializer instances by calling with
+  # a probe to determine behavior.
+  try:
+    # Test with a small shape to determine the initializer type.
+    test_key = jax.random.PRNGKey(0)
+    test_shape = (4, 4)
+    test_out = jax_init(test_key, test_shape, jnp.float32)
+    test_np = np.array(test_out)
+
+    # Check if it's zeros.
+    if np.allclose(test_np, 0.0):
+      return _zeros_init
+
+    # Check if it's ones.
+    if np.allclose(test_np, 1.0):
+      return _ones_init
+  except Exception:
+    pass
+
+  # Try to identify by function name or attributes.
+  name = getattr(jax_init, '__name__', '')
+  qualname = getattr(jax_init, '__qualname__', '')
+  func = getattr(jax_init, 'func', None)
+  func_qualname = getattr(func, '__qualname__', '') if func else ''
+
+  # Variance scaling variants.
+  if 'lecun_normal' in name or 'lecun_normal' in qualname:
+    return _make_variance_scaling_init('fan_in', 'truncated_normal')
+  if 'lecun_uniform' in name or 'lecun_uniform' in qualname:
+    return _make_variance_scaling_init('fan_in', 'uniform')
+  if 'glorot_normal' in name or 'glorot_normal' in qualname:
+    return _make_variance_scaling_init('fan_avg', 'truncated_normal')
+  if 'glorot_uniform' in name or 'glorot_uniform' in qualname:
+    return _make_variance_scaling_init('fan_avg', 'uniform')
+  if 'he_normal' in name or 'he_normal' in qualname:
+    return _make_variance_scaling_init('fan_in', 'normal')
+  if 'he_uniform' in name or 'he_uniform' in qualname:
+    return _make_variance_scaling_init('fan_in', 'uniform')
+  if 'xavier_normal' in name or 'xavier_normal' in qualname:
+    return _make_variance_scaling_init('fan_avg', 'normal')
+  if 'xavier_uniform' in name or 'xavier_uniform' in qualname:
+    return _make_variance_scaling_init('fan_avg', 'uniform')
+
+  # Check for variance_scaling in qualname/func.
+  if 'variance_scaling' in qualname or 'variance_scaling' in func_qualname:
+    return _make_variance_scaling_init('fan_in', 'truncated_normal')
+
+  if 'zeros' in name or 'zeros' in qualname:
+    return _zeros_init
+  if 'ones' in name or 'ones' in qualname:
+    return _ones_init
+
+  # Default fallback: lecun_normal equivalent.
+  return _make_variance_scaling_init('fan_in', 'truncated_normal')
+
+
+# ---------------------------------------------------------------------------
+# Activation mapping
+# ---------------------------------------------------------------------------
+
+_ACTIVATION_MAP = {}
+
+
+def _build_activation_map():
+  """Build the JAX -> MLX activation mapping lazily."""
+  if _ACTIVATION_MAP:
+    return
+  _ACTIVATION_MAP.update({
+      jax.nn.relu: nn.relu,
+      jax.nn.gelu: nn.gelu,
+      jax.nn.silu: nn.silu,
+      jax.nn.swish: nn.silu,  # swish == silu
+      jax.nn.sigmoid: mx.sigmoid,
+      jax.nn.tanh: mx.tanh,
+      jax.nn.softmax: mx.softmax,
+      jax.nn.elu: nn.elu,
+      jax.nn.leaky_relu: nn.leaky_relu,
+      jax.nn.log_softmax: mx.log,  # Approximate.
+  })
+  # Also add jnp versions.
+  for k, v in list(_ACTIVATION_MAP.items()):
+    name = getattr(k, '__name__', '')
+    jnp_fn = getattr(jnp, name, None)
+    if jnp_fn is not None and jnp_fn not in _ACTIVATION_MAP:
+      _ACTIVATION_MAP[jnp_fn] = v
+
+
+def map_activation(jax_activation):
+  """Convert a JAX activation function to its MLX equivalent.
+
+  Args:
+    jax_activation: A JAX activation function (e.g. jax.nn.relu).
+
+  Returns:
+    The corresponding MLX activation, or the original function
+    if no mapping is found.
+  """
+  if jax_activation is None:
+    return None
+  _build_activation_map()
+  return _ACTIVATION_MAP.get(jax_activation, jax_activation)

--- a/sequence_layers/mlx/init_mapping.py
+++ b/sequence_layers/mlx/init_mapping.py
@@ -1,14 +1,12 @@
 """Mapping JAX/Flax initializers and activations to MLX equivalents."""
 
-import functools
 import math
 
 import jax
 import jax.numpy as jnp
+from mlx import nn
 import mlx.core as mx
-import mlx.nn as nn
 import numpy as np
-from flax.linen import initializers as flax_init
 
 
 def _variance_scaling(key, shape, dtype, mode, distribution, fan_in, fan_out):
@@ -32,15 +30,15 @@ def _variance_scaling(key, shape, dtype, mode, distribution, fan_in, fan_out):
         )
         * stddev
     )
-  elif distribution == 'normal':
+  if distribution == 'normal':
     return mx.random.normal(shape=shape, key=key).astype(dtype) * math.sqrt(
         variance
     )
-  elif distribution == 'uniform':
+  if distribution == 'uniform':
     limit = math.sqrt(3.0 * variance)
     return mx.random.uniform(-limit, limit, shape=shape, key=key).astype(dtype)
-  else:
-    raise ValueError(f'Unknown distribution: {distribution}')
+
+  raise ValueError(f'Unknown distribution: {distribution}')
 
 
 def _compute_fans(shape):
@@ -100,16 +98,20 @@ def _to_mx_dtype(dtype):
 
 
 def _zeros_init(key, shape, dtype=mx.float32):
+  """Initializer that generates tensors initialized with 0."""
   del key
   return mx.zeros(shape, dtype=_to_mx_dtype(dtype))
 
 
 def _ones_init(key, shape, dtype=mx.float32):
+  """Initializer that generates tensors initialized with 1."""
   del key
   return mx.ones(shape, dtype=_to_mx_dtype(dtype))
 
 
 def _normal_init(stddev=0.01):
+  """Initializer that generates tensors with a normal distribution."""
+
   def init_fn(key, shape, dtype=mx.float32):
     dtype = _to_mx_dtype(dtype)
     return mx.random.normal(shape=shape, key=key).astype(dtype) * stddev
@@ -145,7 +147,7 @@ def map_initializer(jax_init):
     # Check if it's ones.
     if np.allclose(test_np, 1.0):
       return _ones_init
-  except Exception:
+  except Exception:  # pylint: disable=broad-exception-caught
     pass
 
   # Try to identify by function name or attributes.

--- a/sequence_layers/specs/__init__.py
+++ b/sequence_layers/specs/__init__.py
@@ -5,6 +5,7 @@
 from typing import Protocol, runtime_checkable, TYPE_CHECKING
 
 from . import backend as _backend
+from . import dense as _dense
 from . import simple as _simple
 from . import types as _types
 
@@ -115,4 +116,12 @@ class ModuleSpec(Protocol):
 
   @property
   def Softmax(self) -> type[_simple.Softmax]:
+    ...
+
+  @property
+  def Dense(self) -> type[_dense.Dense]:
+    ...
+
+  @property
+  def EinsumDense(self) -> type[_dense.EinsumDense]:
     ...

--- a/sequence_layers/specs/dense.py
+++ b/sequence_layers/specs/dense.py
@@ -26,7 +26,6 @@ class Dense(types_spec.Stateless, metaclass=abc.ABCMeta):
 
     def make(self) -> Any:
       """Dummy make to satisfy Pyrefly."""
-      pass
 
 
 class EinsumDense(types_spec.Stateless, metaclass=abc.ABCMeta):
@@ -46,4 +45,3 @@ class EinsumDense(types_spec.Stateless, metaclass=abc.ABCMeta):
 
     def make(self) -> Any:
       """Dummy make to satisfy Pyrefly."""
-      pass

--- a/sequence_layers/specs/dense.py
+++ b/sequence_layers/specs/dense.py
@@ -1,0 +1,49 @@
+"""Specifications for dense layers.
+
+See the corresponding _behaviors module for behaviors.
+"""
+
+import abc
+import dataclasses
+from typing import Any, Callable, Sequence
+
+from sequence_layers.specs import types as types_spec
+
+
+class Dense(types_spec.Stateless, metaclass=abc.ABCMeta):
+  """Specification for Dense layer."""
+
+  @dataclasses.dataclass(frozen=True)
+  class Config(types_spec.SequenceLayerConfig):
+    """Configuration for Dense layer."""
+
+    features: int
+    use_bias: bool = True
+    activation: Callable | None = None
+    compute_dtype: types_spec.DType | None = None
+    param_dtype: types_spec.DType | None = None
+    name: str | None = None
+
+    def make(self) -> Any:
+      """Dummy make to satisfy Pyrefly."""
+      pass
+
+
+class EinsumDense(types_spec.Stateless, metaclass=abc.ABCMeta):
+  """Specification for EinsumDense layer."""
+
+  @dataclasses.dataclass(frozen=True)
+  class Config(types_spec.SequenceLayerConfig):
+    """Configuration for EinsumDense layer."""
+
+    equation: str
+    output_shape: Sequence[int | None]
+    bias_axes: str = ''
+    activation: Callable | None = None
+    compute_dtype: types_spec.DType | None = None
+    param_dtype: types_spec.DType | None = None
+    name: str | None = None
+
+    def make(self) -> Any:
+      """Dummy make to satisfy Pyrefly."""
+      pass

--- a/sequence_layers/specs/dense.py
+++ b/sequence_layers/specs/dense.py
@@ -5,12 +5,18 @@ See the corresponding _behaviors module for behaviors.
 
 import abc
 import dataclasses
-from typing import Any, Callable, Sequence
+from typing import Any, Callable, override, Sequence
 
 from sequence_layers.specs import types as types_spec
 
 
-class Dense(types_spec.Stateless, metaclass=abc.ABCMeta):
+class Dense[
+    SequenceT: types_spec.Sequence = types_spec.Sequence,
+    ShapeDTypeT: types_spec.ChannelSpec = types_spec.ChannelSpec,
+](
+    types_spec.Stateless[SequenceT, SequenceT, ShapeDTypeT],
+    metaclass=abc.ABCMeta,
+):
   """Specification for Dense layer."""
 
   @dataclasses.dataclass(frozen=True)
@@ -24,11 +30,18 @@ class Dense(types_spec.Stateless, metaclass=abc.ABCMeta):
     param_dtype: types_spec.DType | None = None
     name: str | None = None
 
+    @override
     def make(self) -> Any:
       """Dummy make to satisfy Pyrefly."""
 
 
-class EinsumDense(types_spec.Stateless, metaclass=abc.ABCMeta):
+class EinsumDense[
+    SequenceT: types_spec.Sequence = types_spec.Sequence,
+    ShapeDTypeT: types_spec.ChannelSpec = types_spec.ChannelSpec,
+](
+    types_spec.Stateless[SequenceT, SequenceT, ShapeDTypeT],
+    metaclass=abc.ABCMeta,
+):
   """Specification for EinsumDense layer."""
 
   @dataclasses.dataclass(frozen=True)
@@ -43,5 +56,6 @@ class EinsumDense(types_spec.Stateless, metaclass=abc.ABCMeta):
     param_dtype: types_spec.DType | None = None
     name: str | None = None
 
+    @override
     def make(self) -> Any:
       """Dummy make to satisfy Pyrefly."""

--- a/sequence_layers/specs/dense_behaviors.py
+++ b/sequence_layers/specs/dense_behaviors.py
@@ -17,7 +17,8 @@ class DenseTest(test_utils.SequenceLayerTest):
     l = self.sl.Dense.Config(features=3, name='dense').make()
     x = self.random_sequence(2, 13)
     with self.assertRaises(ValueError):
-      self.init_layer(l, x)
+      l = self.init_layer(l, x)
+      l.layer(x, training=False)
 
   @parameterized.parameters(((5,),), ((5, 7),))
   def test_dense(self, channels_shape):
@@ -96,6 +97,7 @@ class EinsumDenseTest(test_utils.SequenceLayerTest):
           equation='btabc,bc->btad', output_shape=[None, 2]
       ).make()
       l = self.init_layer(l, x)
+      l.layer(x, training=False)
 
   def test_einsum_dense_inconsistent_input_shape(self):
     x = self.random_sequence(2, 3, 5)
@@ -103,4 +105,5 @@ class EinsumDenseTest(test_utils.SequenceLayerTest):
         equation='...abc,bc->...ad', output_shape=[None, 2]
     ).make()
     with self.assertRaises(ValueError):
-      self.init_layer(l, x)
+      l = self.init_layer(l, x)
+      l.layer(x, training=False)

--- a/sequence_layers/specs/dense_behaviors.py
+++ b/sequence_layers/specs/dense_behaviors.py
@@ -1,0 +1,106 @@
+"""Behavior tests for dense layers.
+
+Backend-specific test files should inherit from these tests.
+"""
+
+# pylint: disable=abstract-method
+
+from absl.testing import parameterized
+
+from sequence_layers.specs import test_utils
+
+
+class DenseTest(test_utils.SequenceLayerTest):
+  """Test behavior of Dense layer."""
+
+  def test_rank2_unsupported(self):
+    l = self.sl.Dense.Config(features=3, name='dense').make()
+    x = self.random_sequence(2, 13)
+    with self.assertRaises(ValueError):
+      self.init_layer(l, x)
+
+  @parameterized.parameters(((5,),), ((5, 7),))
+  def test_dense(self, channels_shape):
+    l = self.sl.Dense.Config(features=3, name='dense').make()
+    x = self.random_sequence(2, 13, *channels_shape, random_mask=True)
+    l = self.init_layer(l, x)
+    self.assertEqual(l.block_size, 1)
+    self.assertEqual(l.output_ratio, 1)
+    self.assertEqual(l.name, 'dense')
+    self.assertEqual(
+        l.get_output_shape_for_sequence(x), channels_shape[:-1] + (3,)
+    )
+    self.verify_contract(l, x, training=False)
+
+  @parameterized.parameters(True, False)
+  def test_use_bias(self, use_bias):
+    l = self.sl.Dense.Config(features=3, use_bias=use_bias).make()
+    x = self.random_sequence(2, 3, 5)
+    l = self.init_layer(l, x)
+    self.verify_contract(l, x, training=False)
+
+
+class EinsumDenseTest(test_utils.SequenceLayerTest):
+  """Test behavior of EinsumDense layer."""
+
+  @parameterized.parameters(
+      (
+          (2, 3, 5),
+          '...a,ab->...b',
+          (7,),
+          '',
+          (7,),
+      ),
+      (
+          (2, 3, 5, 7),
+          '...ab,ac->...cb',
+          (11, 7),
+          'c',
+          (11, 7),
+      ),
+      (
+          (2, 3, 5, 7),
+          '...ab,b->...a',
+          (None,),
+          '',
+          (5,),
+      ),
+  )
+  def test_einsum_dense(
+      self,
+      shape,
+      equation,
+      output_shape,
+      bias_axes,
+      expected_output_shape,
+  ):
+    x = self.random_sequence(*shape)
+    l = self.sl.EinsumDense.Config(
+        equation=equation,
+        output_shape=output_shape,
+        bias_axes=bias_axes,
+        name='einsum_dense',
+    ).make()
+    l = self.init_layer(l, x)
+
+    self.assertEqual(l.block_size, 1)
+    self.assertEqual(l.output_ratio, 1)
+    self.assertEqual(l.name, 'einsum_dense')
+    self.assertEqual(l.get_output_shape_for_sequence(x), expected_output_shape)
+    self.verify_contract(l, x, training=False)
+
+  def test_einsum_dense_nonbroadcasting_equation(self):
+    with self.assertRaises(ValueError):
+      x = self.random_sequence(2, 3, 4, 5, 6)
+      l = self.sl.EinsumDense.Config(
+          equation='btabc,bc->btad', output_shape=[None, 2]
+      ).make()
+      l = self.init_layer(l, x)
+
+  def test_einsum_dense_inconsistent_input_shape(self):
+    x = self.random_sequence(2, 3, 5)
+    l = self.sl.EinsumDense.Config(
+        equation='...abc,bc->...ad', output_shape=[None, 2]
+    ).make()
+    with self.assertRaises(ValueError):
+      self.init_layer(l, x)


### PR DESCRIPTION
- Add MLX `dense.py` implementations ported from DBraun's branch
- Abstract Dense layers into `specs/` and extract shared behavior tests into `dense_behaviors.py`
- Standardize both JAX and MLX tests to inherit from and use shared specs for Dense layers