### PR TITLE
Fix MLX implementation of LocalDotProductSelfAttention that previously overwrote block_size

### DIFF
--- a/sequence_layers/mlx/attention.py
+++ b/sequence_layers/mlx/attention.py
@@ -2398,12 +2398,6 @@ class LocalDotProductSelfAttention(
         kernel_init=kernel_init,
         bias_init=bias_init,
     )
-    self._block_size_config = config.block_size
-
-  @property
-  @override
-  def block_size(self):
-    return self._block_size_config
 
   @classmethod
   @override

--- a/sequence_layers/mlx/attention_test.py
+++ b/sequence_layers/mlx/attention_test.py
@@ -270,7 +270,7 @@ class LocalDotProductSelfAttentionTest(
         mlx_layer,
         attention.LocalDotProductSelfAttention,
     )
-    self.assertEqual(mlx_layer.block_size, 2)
+    self.assertEqual(mlx_layer.block_size, 1)
 
     x = test_utils.random_sequence(1, 8, 8)
     y = mlx_layer.layer(x, training=False)

--- a/sequence_layers/specs/attention_behaviors.py
+++ b/sequence_layers/specs/attention_behaviors.py
@@ -613,6 +613,7 @@ class LocalDotProductSelfAttentionTest(test_utils.SequenceLayerTest):
     x = self.random_sequence(batch_size, time, channels)
     layer = self.init_layer(layer, x)
 
+    self.assertEqual(layer.block_size, 1)
     self.assertEqual(layer.output_ratio, 1)
     self.assertEqual(layer.name, 'local_dot_product_self_attention')
     self.assertEqual(

--- a/sequence_layers/specs/types_behaviors.py
+++ b/sequence_layers/specs/types_behaviors.py
@@ -438,6 +438,43 @@ class SteppableTest(SequenceLayerTest):
     class DefaultSteppable(DefaultTestLayer, backend_sl.types.Steppable):
       """Mock layer for testing."""
 
+      @property
+      @override
+      def block_size(self) -> int:
+        return backend_sl.types.Steppable.block_size.fget(self)
+
+      @property
+      @override
+      def output_ratio(self) -> fractions.Fraction:
+        return backend_sl.types.Steppable.output_ratio.fget(self)
+
+      @property
+      @override
+      def supports_step(self) -> bool:
+        return backend_sl.types.Steppable.supports_step.fget(self)
+
+      @property
+      @override
+      def input_latency(self) -> int:
+        return backend_sl.types.Steppable.input_latency.fget(self)
+
+      @property
+      @override
+      def output_latency(self) -> int:
+        return backend_sl.types.Steppable.output_latency.fget(self)
+
+      @override
+      def get_accumulated_input_latency(self, input_latency: int) -> int:
+        return backend_sl.types.Steppable.get_accumulated_input_latency(
+            self, input_latency
+        )
+
+      @override
+      def get_accumulated_output_latency(self, output_latency: int) -> int:
+        return backend_sl.types.Steppable.get_accumulated_output_latency(
+            self, output_latency
+        )
+
       @override
       def layer_with_emits(self, *args, **kwargs):
         return backend_sl.types.Steppable.layer_with_emits(


### PR DESCRIPTION
The current MLX implementation of `LocalDotProductSelfAttention` does:
```python
@property
@override
def block_size(self):
  return self._block_size_config
```
, which overwrites the `block_size` property of the class and breaks inference using `step`, which needs `block_size=1`. Instead, the JAX implementation does not overwrite the property. This PR fixes the MLX implementation to match the JAX one.

Additionally, this PR adds corresponding attention tests (`self.assertEqual(layer.block_size, 1)`) for the step function, and modifies `DefaultSteppable` to make sure properties are read from base class `backend_sl.types.Steppable` and not `DefaultTestLayer`.